### PR TITLE
add: ci: license checker

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,4 @@ jobs:
       uses: wandera/golangci-lint-action@v3
       with:
         version: v1.51.2
-
+        args: "--out-${NO_FUTURE}format colored-line-number"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   - gci
   - godot
   - gofumpt
+  - goheader
   - gosimple
   - govet
   - gosec
@@ -25,6 +26,9 @@ linters-settings:
     - G304
     - G401
     - G501
+
+  goheader:
+    template: Copyright JAMF Software, LLC
 
 issues:
   exclude-rules:

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,4 +1,4 @@
-// Comode pyright JAMF Software, LLC
+// Copyright JAMF Software, LLC
 
 package cmd
 

--- a/proto/maintenance.proto
+++ b/proto/maintenance.proto
@@ -1,3 +1,5 @@
+// Copyright JAMF Software, LLC
+
 syntax = "proto3";
 
 option go_package = "./proto";

--- a/proto/mvcc.proto
+++ b/proto/mvcc.proto
@@ -1,3 +1,5 @@
+// Copyright JAMF Software, LLC
+
 //
 // Regatta MVCC protobuffer specification
 //

--- a/proto/regatta.proto
+++ b/proto/regatta.proto
@@ -1,3 +1,5 @@
+// Copyright JAMF Software, LLC
+
 //
 // Regatta protobuffer specification
 //

--- a/proto/replication.proto
+++ b/proto/replication.proto
@@ -1,3 +1,5 @@
+// Copyright JAMF Software, LLC
+
 //
 // Regatta replication protobuffer specification
 //


### PR DESCRIPTION
Added go-header linter to check for license headers. [Also changed golangci-lint gh action arguments to display the location of the warning in the action output](https://github.com/golangci/golangci-lint-action/issues/119).