### PR TITLE
add: write snapshotHeader with the snapshot type in it

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,17 @@ nav_order: 999
 # Changelog
 
 ## mainline (unreleased)
-TBD
+
+### Breaking changes
+
+### Features
+
+### Improvements
+* Snapshot recovery type could be switched on a running cluster safely.
+
+### Bugfixes
+
+
 
 ## v0.2.0
 Release is mostly focused on tidying up the docs and code base and on resource consumption improvements.

--- a/storage/table/fsm/snapshot_checkpoint.go
+++ b/storage/table/fsm/snapshot_checkpoint.go
@@ -32,6 +32,12 @@ type checkpoint struct {
 	fsm *FSM
 }
 
+func (c *checkpoint) getHeader() snapshotHeader {
+	h := snapshotHeader{}
+	h.setSnapshotType(RecoveryTypeCheckpoint)
+	return h
+}
+
 func (c *checkpoint) prepare() (any, error) {
 	db := c.fsm.pebble.Load()
 	if err := db.Flush(); err != nil {

--- a/storage/table/fsm/snapshot_snapshot.go
+++ b/storage/table/fsm/snapshot_snapshot.go
@@ -17,10 +17,6 @@ import (
 	sm "github.com/lni/dragonboat/v4/statemachine"
 )
 
-type snapshot struct {
-	fsm *FSM
-}
-
 type snapshotContext struct {
 	*pebble.Snapshot
 	once sync.Once
@@ -29,6 +25,16 @@ type snapshotContext struct {
 func (s *snapshotContext) Close() (err error) {
 	s.once.Do(func() { err = s.Snapshot.Close() })
 	return
+}
+
+type snapshot struct {
+	fsm *FSM
+}
+
+func (s *snapshot) getHeader() snapshotHeader {
+	h := snapshotHeader{}
+	h.setSnapshotType(RecoveryTypeSnapshot)
+	return h
 }
 
 func (s *snapshot) prepare() (any, error) {

--- a/storage/table/fsm/snapshot_test.go
+++ b/storage/table/fsm/snapshot_test.go
@@ -55,7 +55,7 @@ func TestFSM_Snapshot(t *testing.T) {
 			},
 		},
 		{
-			"recover using snapshot (large DB)",
+			"recover using checkpoint (large DB)",
 			args{
 				producingSMFactory: filledLargeValuesSM,
 				receivingSMFactory: emptySM,
@@ -63,7 +63,7 @@ func TestFSM_Snapshot(t *testing.T) {
 			},
 		},
 		{
-			"recover using snapshot (empty DB)",
+			"recover using checkpoint (empty DB)",
 			args{
 				producingSMFactory: filledIndexOnlySM,
 				receivingSMFactory: emptySM,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Write snapshotHeader with the snapshot type in it to allow for mixed cluster.

## Related Issue
None

## Motivation and Context
It solves the situation when the cluster operator wants to switch the snapshot type but there is a recovery in progress or necessary after a restart. The mismatch of a producer and consumer node setting could have lead to a panic.

## How Has This Been Tested?
Unit and integration tests.