### PR TITLE
add: improve replication server/client

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,5 +15,5 @@ jobs:
     - name: Lint
       uses: wandera/golangci-lint-action@v3
       with:
-        version: v1.51.2
+        version: v1.54.1
         args: "--out-${NO_FUTURE}format colored-line-number"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   golangci:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   unit:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ run-follower: build
 check: proto
 	@echo "Running check"
 ifeq (, $(shell which golangci-lint))
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.49.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.54.1
 endif
 	golangci-lint run
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,10 +11,13 @@ nav_order: 999
 ### Breaking changes
 
 ### Features
+* Add `replication.keepalive-time` config option for follower. Sets how often the keepalive should be sent.
+* Add `replication.keepalive-timeout` config option for follower. Sets how long to wait for an ack of the keepalive message.
 
 ### Improvements
 * Snapshot recovery type could be switched on a running cluster safely.
 * Bump to Go 1.21.
+* Keepalive for replication connection to tackle misbehaving LBs.
 
 ### Bugfixes
 

--- a/docs/operations_guide/cli/regatta_follower.md
+++ b/docs/operations_guide/cli/regatta_follower.md
@@ -72,6 +72,8 @@ regatta follower [flags]
                                                               Leave WALDir to have zero value will have everything stored in NodeHostDir.
       --replication.ca-filename string                        Path to the client CA cert file. (default "hack/replication/ca.crt")
       --replication.cert-filename string                      Path to the client certificate. (default "hack/replication/client.crt")
+      --replication.keepalive-time duration                   After a duration of this time if the replication client doesn't see any activity it pings the server to see if the transport is still alive. If set below 10s, a minimum value of 10s will be used instead. (default 1m0s)
+      --replication.keepalive-timeout duration                After having pinged for keepalive check, the replication client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --replication.key-filename string                       Path to the client private key file. (default "hack/replication/client.key")
       --replication.leader-address string                     Address of the leader replication API to connect to. (default "localhost:8444")
       --replication.lease-interval duration                   Interval in which the workers re-new their table leases. (default 15s)

--- a/replication/worker.go
+++ b/replication/worker.go
@@ -161,8 +161,10 @@ func (w *worker) Start() {
 								w.log.Warnf("error retruning table: %v", err)
 							}
 						}
+					case errors.Is(err, context.DeadlineExceeded):
+						w.log.Warnf("unable to read leader log in time: %v", err)
 					default:
-						w.log.Warnf("worker error: %v", err)
+						w.log.Warnf("uknown worker error: %v", err)
 					}
 					continue
 				}

--- a/storage/kv/kv.go
+++ b/storage/kv/kv.go
@@ -25,24 +25,6 @@ type Pair struct {
 	Ver uint64
 }
 
-// Pairs slice of Pair that could be sorted.
-type Pairs []Pair
-
-// Len is the number of elements in the collection.
-func (p Pairs) Len() int {
-	return len(p)
-}
-
-// Less reports whether the element with index i must sort before the element with index j.
-func (p Pairs) Less(i, j int) bool {
-	return p[i].Key < p[j].Key
-}
-
-// Swap swaps the elements with indexes i and j.
-func (p Pairs) Swap(i, j int) {
-	p[i], p[j] = p[j], p[i]
-}
-
 func stripKey(key, prefix string) string {
 	return strings.TrimPrefix(strings.TrimPrefix(key, prefix), "/")
 }

--- a/storage/kv/kv_test.go
+++ b/storage/kv/kv_test.go
@@ -49,7 +49,7 @@ type store interface {
 	Delete(key string, ver uint64) error
 	Exists(key string) (bool, error)
 	Get(key string) (Pair, error)
-	GetAll(pattern string) (Pairs, error)
+	GetAll(pattern string) ([]Pair, error)
 	GetAllValues(pattern string) ([]string, error)
 	List(filePath string) ([]string, error)
 	ListDir(filePath string) ([]string, error)
@@ -213,7 +213,7 @@ func TestStore_GetAll(t *testing.T) {
 		name      string
 		args      args
 		store     func() store
-		want      Pairs
+		want      []Pair
 		wantCount int
 		wantErr   error
 	}{
@@ -331,7 +331,7 @@ func TestStore_GetAll(t *testing.T) {
 			}
 			r.NoError(err)
 			if tt.wantCount > 0 {
-				r.Equal(tt.wantCount, got.Len())
+				r.Equal(tt.wantCount, len(got))
 			} else {
 				r.Equal(tt.want, got)
 			}

--- a/storage/kv/map.go
+++ b/storage/kv/map.go
@@ -3,11 +3,13 @@
 package kv
 
 import (
+	"cmp"
 	"encoding/json"
 	"path"
-	"sort"
 	"strings"
 	"sync"
+
+	"golang.org/x/exp/slices"
 )
 
 // A MapStore represents an in-memory key-value store safe for
@@ -52,8 +54,8 @@ func (s *MapStore) Get(key string) (Pair, error) {
 
 // GetAll returns a Pair for all nodes with keys matching pattern.
 // The syntax of patterns is the same as in path.Match.
-func (s *MapStore) GetAll(pattern string) (Pairs, error) {
-	ks := make(Pairs, 0)
+func (s *MapStore) GetAll(pattern string) ([]Pair, error) {
+	ks := make([]Pair, 0)
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	for _, kv := range s.m {
@@ -68,7 +70,9 @@ func (s *MapStore) GetAll(pattern string) (Pairs, error) {
 	if len(ks) == 0 {
 		return ks, nil
 	}
-	sort.Sort(ks)
+	slices.SortFunc(ks, func(a, b Pair) int {
+		return cmp.Compare(a.Key, b.Key)
+	})
 	return ks, nil
 }
 
@@ -86,7 +90,7 @@ func (s *MapStore) GetAllValues(pattern string) ([]string, error) {
 	for _, kv := range ks {
 		vs = append(vs, kv.Value)
 	}
-	sort.Strings(vs)
+	slices.Sort(vs)
 	return vs, nil
 }
 
@@ -109,7 +113,7 @@ func (s *MapStore) List(filePath string) ([]string, error) {
 	for k := range m {
 		vs = append(vs, k)
 	}
-	sort.Strings(vs)
+	slices.Sort(vs)
 	return vs, nil
 }
 
@@ -130,7 +134,7 @@ func (s *MapStore) ListDir(filePath string) ([]string, error) {
 	for k := range m {
 		vs = append(vs, k)
 	}
-	sort.Strings(vs)
+	slices.Sort(vs)
 	return vs, nil
 }
 

--- a/storage/kv/raft.go
+++ b/storage/kv/raft.go
@@ -192,14 +192,14 @@ func (r *RaftStore) Get(key string) (Pair, error) {
 	return val.(Pair), nil
 }
 
-func (r *RaftStore) GetAll(pattern string) (Pairs, error) {
+func (r *RaftStore) GetAll(pattern string) ([]Pair, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), proposalTimeout)
 	defer cancel()
 	val, err := r.NodeHost.SyncRead(ctx, r.ClusterID, QueryAll{Pattern: pattern})
 	if err != nil {
 		return nil, err
 	}
-	return val.(Pairs), nil
+	return val.([]Pair), nil
 }
 
 func (r *RaftStore) GetAllValues(pattern string) ([]string, error) {

--- a/storage/table/manager.go
+++ b/storage/table/manager.go
@@ -30,7 +30,7 @@ type store interface {
 	Set(key string, value string, ver uint64) (kv.Pair, error)
 	Delete(key string, ver uint64) error
 	Get(key string) (kv.Pair, error)
-	GetAll(pattern string) (kv.Pairs, error)
+	GetAll(pattern string) ([]kv.Pair, error)
 }
 
 const (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improve handling of replication connection, send periodic keepalives even when streaming no data to keep the connection open.

## Related Issue

#114 

## Motivation and Context

The replication connection could be suddenly snapped (especially by AWS NLBs) which might break the connection and leave it in unrecoverable state.

