### PR TITLE
add: improve follower replication throughput

### DIFF
--- a/cmd/follower.go
+++ b/cmd/follower.go
@@ -47,7 +47,7 @@ func init() {
 	followerCmd.PersistentFlags().String("replication.cert-filename", "hack/replication/client.crt", "Path to the client certificate.")
 	followerCmd.PersistentFlags().String("replication.key-filename", "hack/replication/client.key", "Path to the client private key file.")
 	followerCmd.PersistentFlags().String("replication.ca-filename", "hack/replication/ca.crt", "Path to the client CA cert file.")
-	followerCmd.PersistentFlags().Duration("replication.poll-interval", 10*time.Second, "Replication interval in seconds, the leader poll time.")
+	followerCmd.PersistentFlags().Duration("replication.poll-interval", 1*time.Second, "Replication interval in seconds, the leader poll time.")
 	followerCmd.PersistentFlags().Duration("replication.reconcile-interval", 30*time.Second, "Replication interval of tables reconciliation (workers startup/shutdown).")
 	followerCmd.PersistentFlags().Duration("replication.lease-interval", 15*time.Second, "Interval in which the workers re-new their table leases.")
 	followerCmd.PersistentFlags().Duration("replication.log-rpc-timeout", 1*time.Minute, "The log RPC timeout.")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ nav_order: 999
 * Add `replication.keepalive-timeout` config option for follower. Sets how long to wait for an ack of the keepalive message.
 
 ### Improvements
+* Improve follower replication throughput and latency.
 * Snapshot recovery type could be switched on a running cluster safely.
 * Bump to Go 1.21.
 * Keepalive for replication connection to tackle misbehaving LBs.

--- a/docs/operations_guide/cli/regatta_follower.md
+++ b/docs/operations_guide/cli/regatta_follower.md
@@ -81,7 +81,7 @@ regatta follower [flags]
       --replication.max-recovery-in-flight uint               The maximum number of recovery goroutines allowed to run in this instance. (default 1)
       --replication.max-recv-message-size-bytes uint          The maximum size of single replication message allowed to receive. (default 8388608)
       --replication.max-snapshot-recv-bytes-per-second uint   Maximum bytes per second received by the snapshot API client, default value 0 means unlimited.
-      --replication.poll-interval duration                    Replication interval in seconds, the leader poll time. (default 10s)
+      --replication.poll-interval duration                    Replication interval in seconds, the leader poll time. (default 1s)
       --replication.reconcile-interval duration               Replication interval of tables reconciliation (workers startup/shutdown). (default 30s)
       --replication.snapshot-rpc-timeout duration             The snapshot RPC timeout. (default 1h0m0s)
       --rest.address string                                   REST API server address. (default ":8079")

--- a/regattaserver/replication.go
+++ b/regattaserver/replication.go
@@ -147,7 +147,7 @@ func (l *LogServer) Replicate(req *regattapb.ReplicateRequest, server regattapb.
 	}
 
 	ctx := server.Context()
-	appliedIndex, err := t.LocalIndex(ctx)
+	appliedIndex, err := t.LocalIndex(ctx, true)
 	if err != nil {
 		return err
 	}
@@ -175,6 +175,11 @@ func (l *LogServer) Replicate(req *regattapb.ReplicateRequest, server regattapb.
 		}
 
 		if len(entries) == 0 {
+			// query index for update.
+			appliedIndex, err := t.LocalIndex(ctx, false)
+			if err != nil {
+				return err
+			}
 			if err := server.Send(&regattapb.ReplicateResponse{LeaderIndex: appliedIndex.Index}); err != nil {
 				return err
 			}

--- a/replication/worker_test.go
+++ b/replication/worker_test.go
@@ -74,7 +74,8 @@ func Test_worker_do(t *testing.T) {
 	w := f.create("test")
 	idx, id, err := w.tableState()
 	r.NoError(err)
-	r.NoError(w.do(idx, id))
+	_, err = w.do(idx, id)
+	r.NoError(err)
 	table, err := followerTM.GetTable("test")
 	r.NoError(err)
 
@@ -106,7 +107,8 @@ func Test_worker_do(t *testing.T) {
 	r.Equal(uint64(0), idx)
 
 	t.Log("do after reset")
-	r.NoError(w.do(idx, id))
+	_, err = w.do(idx, id)
+	r.NoError(err)
 
 	idxAfter, _, err := w.tableState()
 	r.NoError(err)
@@ -192,7 +194,7 @@ func Test_worker_recover(t *testing.T) {
 	tab, err := followerTM.GetTable("test")
 	r.NoError(err)
 	r.Equal("test", tab.Name)
-	ir, err := tab.LeaderIndex(ctx)
+	ir, err := tab.LeaderIndex(ctx, false)
 	r.NoError(err)
 	r.Greater(ir.Index, uint64(1))
 

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -673,7 +673,7 @@ func createTable(t *testing.T, e *Engine) {
 		}
 		c, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		_, err = tab.LocalIndex(c)
+		_, err = tab.LocalIndex(c, true)
 		return err == nil
 	}, 1*time.Second, 10*time.Millisecond)
 }

--- a/storage/table/table.go
+++ b/storage/table/table.go
@@ -217,13 +217,13 @@ func (t *ActiveTable) Snapshot(ctx context.Context, writer io.Writer) (*fsm.Snap
 }
 
 // LocalIndex returns local index.
-func (t *ActiveTable) LocalIndex(ctx context.Context) (*fsm.IndexResponse, error) {
-	return readTable[*fsm.IndexResponse](t, ctx, true, fsm.LocalIndexRequest{})
+func (t *ActiveTable) LocalIndex(ctx context.Context, linearizable bool) (*fsm.IndexResponse, error) {
+	return readTable[*fsm.IndexResponse](t, ctx, linearizable, fsm.LocalIndexRequest{})
 }
 
 // LeaderIndex returns leader index.
-func (t *ActiveTable) LeaderIndex(ctx context.Context) (*fsm.IndexResponse, error) {
-	return readTable[*fsm.IndexResponse](t, ctx, true, fsm.LeaderIndexRequest{})
+func (t *ActiveTable) LeaderIndex(ctx context.Context, linearizable bool) (*fsm.IndexResponse, error) {
+	return readTable[*fsm.IndexResponse](t, ctx, linearizable, fsm.LeaderIndexRequest{})
 }
 
 // Reset resets the leader index to 0.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Redesign the follower replication routine so that it gets immediately triggered when there is known outstanding lag.
The leader sends the updated index as a last message within the stream so that the follower is able to discover that it is lagging thus invokes another Replicate call immediately.

## Related Issue
#114 

## Motivation and Context
* In case of high write volume within leader cluster followers could start to lag behind quickly
* The poll time (default) was too long to cover high ingestion rate of a client which could have lead to reload from snapshot on the follower

## How Has This Been Tested?
* UTs
* ITs
* The issue is easy to simulate even locally by running
  * Run `make run`
  * Run `make follower`
  * Run 
        ```bash
        ghz --skipTLS --call=regatta.v1.KV/Put \
        -c 10 -n 100000 \
        --data='{
          "table": "{{`regatta-test` | b64enc}}",
          "key": "{{newUUID | b64enc}}",
          "value": "{{(randomString 1024) | b64enc}}"
        }' \
        localhost:8443
        ```
  * Observe that the follower will inevitably recovers from snapshot before the change, it does follow leader nicely after the change
