### PR TITLE
add: possibility to turn off server log cache

### DIFF
--- a/cmd/leader.go
+++ b/cmd/leader.go
@@ -52,7 +52,7 @@ Under some circumstances, a larger message could be sent. Followers should be ab
 	leaderCmd.PersistentFlags().String("replication.cert-filename", "hack/replication/server.crt", "Path to the API server certificate.")
 	leaderCmd.PersistentFlags().String("replication.key-filename", "hack/replication/server.key", "Path to the API server private key file.")
 	leaderCmd.PersistentFlags().String("replication.ca-filename", "hack/replication/ca.crt", "Path to the API server CA cert file.")
-	leaderCmd.PersistentFlags().Int("replication.log-cache-size", regattaserver.DefaultCacheSize, "Size of the replication cache.")
+	leaderCmd.PersistentFlags().Int("replication.log-cache-size", 0, "Size of the replication cache. Size 0 means cache is turned off.")
 }
 
 var leaderCmd = &cobra.Command{

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ nav_order: 999
 ## mainline (unreleased)
 
 ### Breaking changes
+* Leader `replication.logCacheSize` now defaults to 0.
 
 ### Features
 * Add `replication.keepalive-time` config option for follower. Sets how often the keepalive should be sent.

--- a/docs/operations_guide/cli/regatta_leader.md
+++ b/docs/operations_guide/cli/regatta_leader.md
@@ -75,7 +75,7 @@ regatta leader [flags]
       --replication.cert-filename string               Path to the API server certificate. (default "hack/replication/server.crt")
       --replication.enabled                            Whether replication API is enabled. (default true)
       --replication.key-filename string                Path to the API server private key file. (default "hack/replication/server.key")
-      --replication.log-cache-size int                 Size of the replication cache. (default 1024)
+      --replication.log-cache-size int                 Size of the replication cache. Size 0 means cache is turned off.
       --replication.max-send-message-size-bytes uint   The target maximum size of single replication message allowed to send.
                                                        Under some circumstances, a larger message could be sent. Followers should be able to accept slightly larger messages. (default 4194304)
       --rest.address string                            REST API server address. (default ":8079")

--- a/regattaserver/replication.go
+++ b/regattaserver/replication.go
@@ -23,8 +23,6 @@ import (
 const (
 	// DefaultMaxGRPCSize is the default maximum size of body of gRPC message to be loaded from dragonboat.
 	DefaultMaxGRPCSize = 4 * 1024 * 1024
-	// DefaultCacheSize is a size of the cache used during the replication routine.
-	DefaultCacheSize = 1024
 )
 
 // MetadataServer implements Metadata service from proto/replication.proto.

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -703,7 +703,7 @@ func newTestEngine(cfg Config) *Engine {
 		panic(err)
 	}
 	e.NodeHost = nh
-	e.LogReader = &logreader.LogReader{LogQuerier: nh}
+	e.LogReader = &logreader.Cached{LogQuerier: nh}
 	e.Cluster, err = cluster.New(cfg.Gossip.BindAddress, cfg.Gossip.AdvertiseAddress, e.clusterInfo)
 	if err != nil {
 		panic(err)

--- a/storage/table/fsm/fsm.go
+++ b/storage/table/fsm/fsm.go
@@ -468,7 +468,7 @@ func makeLoggingEventListener(logger *zap.SugaredLogger) pebble.EventListener {
 			logger.Debugf("%s", info)
 		},
 		CompactionEnd: func(info pebble.CompactionInfo) {
-			logger.Infof("%s", info)
+			logger.Debugf("%s", info)
 		},
 		DiskSlow: func(info pebble.DiskSlowInfo) {
 			logger.Warnf("%s", info)
@@ -507,7 +507,7 @@ func makeLoggingEventListener(logger *zap.SugaredLogger) pebble.EventListener {
 			logger.Infof("%s", info)
 		},
 		WriteStallEnd: func() {
-			logger.Infof("write stall ending")
+			logger.Debugf("write stall ending")
 		},
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improve the case when LogCache size is set to 0. The caching is then skipped altogether.

## Related Issue
NA

## Motivation and Context
* There is a growing suspicion that the logcache is causing significant delays in replication of sparsely changed/populated data.

## How Has This Been Tested?
* In testing env
* UTs
