### PR TITLE
feat: improve Engine events handling and server startup error reporting

### DIFF
--- a/cmd/follower.go
+++ b/cmd/follower.go
@@ -87,7 +87,8 @@ func follower(_ *cobra.Command, _ []string) {
 	}()
 	zap.ReplaceGlobals(logger)
 	log := logger.Sugar().Named("root")
-	setupDragonboatLogger(logger.Named("engine"))
+	engineLog := logger.Named("engine")
+	setupDragonboatLogger(engineLog)
 
 	autoSetMaxprocs(log)
 
@@ -96,6 +97,7 @@ func follower(_ *cobra.Command, _ []string) {
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
 	engine, err := storage.New(storage.Config{
+		Log:           engineLog.Sugar(),
 		ClientAddress: viper.GetString("api.address"),
 		NodeID:        viper.GetUint64("raft.node-id"),
 		InitialMembers: func() map[uint64]string {

--- a/cmd/follower.go
+++ b/cmd/follower.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -62,7 +61,7 @@ func init() {
 var followerCmd = &cobra.Command{
 	Use:   "follower",
 	Short: "Start Regatta in follower mode.",
-	Run:   follower,
+	RunE:  follower,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		initConfig(cmd.PersistentFlags())
 		return validateFollowerConfig()
@@ -80,7 +79,7 @@ func validateFollowerConfig() error {
 	return nil
 }
 
-func follower(_ *cobra.Command, _ []string) {
+func follower(_ *cobra.Command, _ []string) error {
 	logger := rl.NewLogger(viper.GetBool("dev-mode"), viper.GetString("log-level"))
 	defer func() {
 		_ = logger.Sync()
@@ -96,17 +95,21 @@ func follower(_ *cobra.Command, _ []string) {
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
+	initialMembers, err := parseInitialMembers(viper.GetStringMapString("raft.initial-members"))
+	if err != nil {
+		return fmt.Errorf("failed to parse raft.initial-members: %w", err)
+	}
+
+	logDBImpl, err := parseLogDBImplementation(viper.GetString("raft.logdb"))
+	if err != nil {
+		return fmt.Errorf("failed to parse raft.logdb: %w", err)
+	}
+
 	engine, err := storage.New(storage.Config{
-		Log:           engineLog.Sugar(),
-		ClientAddress: viper.GetString("api.address"),
-		NodeID:        viper.GetUint64("raft.node-id"),
-		InitialMembers: func() map[uint64]string {
-			initialMembers, err := parseInitialMembers(viper.GetStringMapString("raft.initial-members"))
-			if err != nil {
-				log.Panic(err)
-			}
-			return initialMembers
-		}(),
+		Log:                 engineLog.Sugar(),
+		ClientAddress:       viper.GetString("api.address"),
+		NodeID:              viper.GetUint64("raft.node-id"),
+		InitialMembers:      initialMembers,
 		WALDir:              viper.GetString("raft.wal-dir"),
 		NodeHostDir:         viper.GetString("raft.node-host-dir"),
 		RTTMillisecond:      uint64(viper.GetDuration("raft.rtt").Milliseconds()),
@@ -139,23 +142,13 @@ func follower(_ *cobra.Command, _ []string) {
 			CompactionOverhead: viper.GetUint64("raft.compaction-overhead"),
 			MaxInMemLogSize:    viper.GetUint64("raft.max-in-mem-log-size"),
 		},
-		LogDBImplementation: func() storage.LogDBImplementation {
-			switch viper.GetString("raft.logdb") {
-			case "pebble":
-				return storage.Pebble
-			case "tan":
-				return storage.Tan
-			default:
-				log.Panicf("unknown logdb impl: %s", viper.GetString("raft.logdb"))
-			}
-			return storage.Pebble
-		}(),
+		LogDBImplementation: logDBImpl,
 	})
 	if err != nil {
-		log.Panic(err)
+		return fmt.Errorf("failed to create engine: %w", err)
 	}
 	if err := engine.Start(); err != nil {
-		log.Panic(err)
+		return fmt.Errorf("failed to start engine: %w", err)
 	}
 	defer engine.Close()
 
@@ -166,7 +159,7 @@ func follower(_ *cobra.Command, _ []string) {
 			_ = conn.Close()
 		}()
 		if err != nil {
-			log.Panicf("cannot create replication conn: %v", err)
+			return fmt.Errorf("cannot create replication conn: %w", err)
 		}
 
 		d := replication.NewManager(engine.Manager, engine.NodeHost, conn, replication.Config{
@@ -190,7 +183,10 @@ func follower(_ *cobra.Command, _ []string) {
 		{
 			// Create regatta API server
 			// Create server
-			regatta := createAPIServer()
+			regatta, err := createAPIServer()
+			if err != nil {
+				return fmt.Errorf("failed to create API server: %w", err)
+			}
 			regattapb.RegisterKVServer(regatta, &regattaserver.ReadonlyKVServer{
 				KVServer: regattaserver.KVServer{
 					Storage: engine,
@@ -202,19 +198,22 @@ func follower(_ *cobra.Command, _ []string) {
 			// Start server
 			go func() {
 				if err := regatta.ListenAndServe(); err != nil {
-					log.Panicf("grpc listenAndServe failed: %v", err)
+					log.Errorf("grpc listenAndServe failed: %v", err)
 				}
 			}()
 			defer regatta.Shutdown()
 		}
 
 		if viper.GetBool("maintenance.enabled") {
-			maintenance := createMaintenanceServer()
+			maintenance, err := createMaintenanceServer()
+			if err != nil {
+				return fmt.Errorf("failed to create Maintenance server: %w", err)
+			}
 			regattapb.RegisterMaintenanceServer(maintenance, &regattaserver.ResetServer{Tables: engine})
 			// Start server
 			go func() {
 				if err := maintenance.ListenAndServe(); err != nil {
-					log.Panicf("grpc listenAndServe failed: %v", err)
+					log.Errorf("grpc listenAndServe failed: %v", err)
 				}
 			}()
 			defer maintenance.Shutdown()
@@ -224,7 +223,7 @@ func follower(_ *cobra.Command, _ []string) {
 		hs := regattaserver.NewRESTServer(viper.GetString("rest.address"), viper.GetDuration("rest.read-timeout"))
 		go func() {
 			if err := hs.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-				log.Panicf("REST listenAndServe failed: %v", err)
+				log.Errorf("REST listenAndServe failed: %v", err)
 			}
 		}()
 		defer hs.Shutdown()
@@ -233,6 +232,7 @@ func follower(_ *cobra.Command, _ []string) {
 	// Cleanup
 	<-shutdown
 	log.Info("shutting down...")
+	return nil
 }
 
 func createReplicationConn() (*grpc.ClientConn, error) {
@@ -241,12 +241,12 @@ func createReplicationConn() (*grpc.ClientConn, error) {
 	if secure {
 		c, err := cert.New(viper.GetString("replication.cert-filename"), viper.GetString("replication.key-filename"))
 		if err != nil {
-			log.Panicf("cannot load certificate: %v", err)
+			return nil, fmt.Errorf("cannot load certificate: %w", err)
 		}
 
 		caBytes, err := os.ReadFile(viper.GetString("replication.ca-filename"))
 		if err != nil {
-			log.Panicf("cannot load server CA: %v", err)
+			return nil, fmt.Errorf("cannot load server CA: %w", err)
 		}
 		cp := x509.NewCertPool()
 		cp.AppendCertsFromPEM(caBytes)

--- a/cmd/leader.go
+++ b/cmd/leader.go
@@ -80,7 +80,8 @@ func leader(_ *cobra.Command, _ []string) {
 	}()
 	zap.ReplaceGlobals(logger)
 	log := logger.Sugar().Named("root")
-	setupDragonboatLogger(logger.Named("engine"))
+	engineLog := logger.Named("engine")
+	setupDragonboatLogger(engineLog)
 
 	autoSetMaxprocs(log)
 
@@ -89,6 +90,7 @@ func leader(_ *cobra.Command, _ []string) {
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
 	engine, err := storage.New(storage.Config{
+		Log:           engineLog.Sugar(),
 		ClientAddress: viper.GetString("api.address"),
 		NodeID:        viper.GetUint64("raft.node-id"),
 		InitialMembers: func() map[uint64]string {

--- a/cmd/leader.go
+++ b/cmd/leader.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -58,7 +59,7 @@ Under some circumstances, a larger message could be sent. Followers should be ab
 var leaderCmd = &cobra.Command{
 	Use:   "leader",
 	Short: "Start Regatta in leader mode.",
-	Run:   leader,
+	RunE:  leader,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		initConfig(cmd.PersistentFlags())
 		return validateLeaderConfig()
@@ -73,7 +74,7 @@ func validateLeaderConfig() error {
 	return nil
 }
 
-func leader(_ *cobra.Command, _ []string) {
+func leader(_ *cobra.Command, _ []string) error {
 	logger := rl.NewLogger(viper.GetBool("dev-mode"), viper.GetString("log-level"))
 	defer func() {
 		_ = logger.Sync()
@@ -89,17 +90,21 @@ func leader(_ *cobra.Command, _ []string) {
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
+	initialMembers, err := parseInitialMembers(viper.GetStringMapString("raft.initial-members"))
+	if err != nil {
+		return fmt.Errorf("failed to parse raft.initial-members: %w", err)
+	}
+
+	logDBImpl, err := parseLogDBImplementation(viper.GetString("raft.logdb"))
+	if err != nil {
+		return fmt.Errorf("failed to parse raft.logdb: %w", err)
+	}
+
 	engine, err := storage.New(storage.Config{
-		Log:           engineLog.Sugar(),
-		ClientAddress: viper.GetString("api.address"),
-		NodeID:        viper.GetUint64("raft.node-id"),
-		InitialMembers: func() map[uint64]string {
-			initialMembers, err := parseInitialMembers(viper.GetStringMapString("raft.initial-members"))
-			if err != nil {
-				log.Panic(err)
-			}
-			return initialMembers
-		}(),
+		Log:                 engineLog.Sugar(),
+		ClientAddress:       viper.GetString("api.address"),
+		NodeID:              viper.GetUint64("raft.node-id"),
+		InitialMembers:      initialMembers,
 		WALDir:              viper.GetString("raft.wal-dir"),
 		NodeHostDir:         viper.GetString("raft.node-host-dir"),
 		RTTMillisecond:      uint64(viper.GetDuration("raft.rtt").Milliseconds()),
@@ -133,24 +138,13 @@ func leader(_ *cobra.Command, _ []string) {
 			CompactionOverhead: viper.GetUint64("raft.compaction-overhead"),
 			MaxInMemLogSize:    viper.GetUint64("raft.max-in-mem-log-size"),
 		},
-		LogDBImplementation: func() storage.LogDBImplementation {
-			switch viper.GetString("raft.logdb") {
-			case "pebble":
-				return storage.Pebble
-			case "tan":
-				return storage.Tan
-			default:
-				log.Panicf("unknown logdb impl: %s", viper.GetString("raft.logdb"))
-			}
-			return storage.Pebble
-		}(),
-	},
-	)
+		LogDBImplementation: logDBImpl,
+	})
 	if err != nil {
-		log.Panic(err)
+		return fmt.Errorf("failed to create engine: %w", err)
 	}
 	if err := engine.Start(); err != nil {
-		log.Panic(err)
+		return fmt.Errorf("failed to start engine: %w", err)
 	}
 	defer engine.Close()
 
@@ -185,7 +179,10 @@ func leader(_ *cobra.Command, _ []string) {
 	{
 		// Create regatta API server
 		{
-			regatta := createAPIServer()
+			regatta, err := createAPIServer()
+			if err != nil {
+				return fmt.Errorf("failed to create API server: %w", err)
+			}
 			regattapb.RegisterKVServer(regatta, &regattaserver.KVServer{
 				Storage: engine,
 			})
@@ -195,7 +192,7 @@ func leader(_ *cobra.Command, _ []string) {
 			// Start server
 			go func() {
 				if err := regatta.ListenAndServe(); err != nil {
-					log.Panicf("grpc listenAndServe failed: %v", err)
+					log.Errorf("grpc listenAndServe failed: %v", err)
 				}
 			}()
 			defer regatta.Shutdown()
@@ -203,7 +200,10 @@ func leader(_ *cobra.Command, _ []string) {
 
 		if viper.GetBool("replication.enabled") {
 			// Load replication API certificate
-			replication := createReplicationServer(logger.Named("server.replication"))
+			replication, err := createReplicationServer(logger.Named("server.replication"))
+			if err != nil {
+				return fmt.Errorf("failed to create Replication server: %w", err)
+			}
 			ls := regattaserver.NewLogServer(
 				engine.Manager,
 				engine.LogReader,
@@ -216,20 +216,23 @@ func leader(_ *cobra.Command, _ []string) {
 			// Start server
 			go func() {
 				if err := replication.ListenAndServe(); err != nil {
-					log.Panicf("grpc listenAndServe failed: %v", err)
+					log.Errorf("grpc listenAndServe failed: %v", err)
 				}
 			}()
 			defer replication.Shutdown()
 		}
 
 		if viper.GetBool("maintenance.enabled") {
-			maintenance := createMaintenanceServer()
+			maintenance, err := createMaintenanceServer()
+			if err != nil {
+				return fmt.Errorf("failed to create Maintenance server: %w", err)
+			}
 			regattapb.RegisterMetadataServer(maintenance, &regattaserver.MetadataServer{Tables: engine})
 			regattapb.RegisterMaintenanceServer(maintenance, &regattaserver.BackupServer{Tables: engine})
 			// Start server
 			go func() {
 				if err := maintenance.ListenAndServe(); err != nil {
-					log.Panicf("grpc listenAndServe failed: %v", err)
+					log.Errorf("grpc listenAndServe failed: %v", err)
 				}
 			}()
 			defer maintenance.Shutdown()
@@ -240,7 +243,7 @@ func leader(_ *cobra.Command, _ []string) {
 		hs := regattaserver.NewRESTServer(addr, viper.GetDuration("rest.read-timeout"))
 		go func() {
 			if err := hs.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-				log.Panicf("REST listenAndServe failed: %v", err)
+				log.Errorf("REST listenAndServe failed: %v", err)
 			}
 		}()
 		defer hs.Shutdown()
@@ -249,9 +252,10 @@ func leader(_ *cobra.Command, _ []string) {
 	// Cleanup
 	<-shutdown
 	log.Info("shutting down...")
+	return nil
 }
 
-func createReplicationServer(log *zap.Logger) *regattaserver.RegattaServer {
+func createReplicationServer(log *zap.Logger) (*regattaserver.RegattaServer, error) {
 	addr, secure, net := resolveUrl(viper.GetString("replication.address"))
 	opts := []grpc.ServerOption{
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
@@ -266,11 +270,11 @@ func createReplicationServer(log *zap.Logger) *regattaserver.RegattaServer {
 	if secure {
 		c, err := cert.New(viper.GetString("replication.cert-filename"), viper.GetString("replication.key-filename"))
 		if err != nil {
-			log.Sugar().Panicf("cannot load replication certificate: %v", err)
+			return nil, fmt.Errorf("cannot load replication certificate: %w", err)
 		}
 		caBytes, err := os.ReadFile(viper.GetString("replication.ca-filename"))
 		if err != nil {
-			log.Sugar().Panicf("cannot load clients CA: %v", err)
+			return nil, fmt.Errorf("cannot load clients CA: %w", err)
 		}
 		cp := x509.NewCertPool()
 		cp.AppendCertsFromPEM(caBytes)
@@ -282,7 +286,7 @@ func createReplicationServer(log *zap.Logger) *regattaserver.RegattaServer {
 		}))
 	}
 	// Create regatta replication server
-	return regattaserver.NewServer(addr, net, opts...)
+	return regattaserver.NewServer(addr, net, opts...), nil
 }
 
 func logDeciderFunc(_ string, err error) bool {

--- a/storage/config.go
+++ b/storage/config.go
@@ -5,6 +5,7 @@ package storage
 import (
 	"github.com/jamf/regatta/storage/table"
 	"github.com/lni/vfs"
+	"go.uber.org/zap"
 )
 
 type LogDBImplementation int
@@ -103,4 +104,6 @@ type Config struct {
 	// FS is the filesystem to use for log store, useful for testing,
 	// uses the real vfs.Default if nil.
 	FS vfs.FS
+	// Logger implementation for storage.
+	Log *zap.SugaredLogger
 }

--- a/storage/engine_events.go
+++ b/storage/engine_events.go
@@ -1,0 +1,267 @@
+// Copyright JAMF Software, LLC
+
+package storage
+
+import (
+	"github.com/lni/dragonboat/v4/raftio"
+)
+
+func (e *Engine) dispatchEvents() {
+	for {
+		select {
+		case <-e.stop:
+			return
+		case evt := <-e.eventsCh:
+			e.log.Infof("raft: %T %+v", evt, evt)
+			switch ev := evt.(type) {
+			case leaderUpdated, nodeUnloaded, membershipChanged, nodeHostShuttingDown:
+				e.Cluster.Notify()
+			case nodeReady:
+				if ev.ReplicaID == e.cfg.NodeID && e.LogCache != nil {
+					e.LogCache.NodeReady(ev.ShardID)
+				}
+				e.Cluster.Notify()
+			case nodeDeleted:
+				if ev.ReplicaID == e.cfg.NodeID && e.LogCache != nil {
+					e.LogCache.NodeDeleted(ev.ShardID)
+				}
+				e.Cluster.Notify()
+			case logCompacted:
+				if ev.ReplicaID == e.cfg.NodeID && e.LogCache != nil {
+					e.LogCache.LogCompacted(ev.ShardID)
+				}
+				e.Cluster.Notify()
+			}
+		}
+	}
+}
+
+type leaderUpdated struct {
+	ShardID   uint64
+	ReplicaID uint64
+	Term      uint64
+	LeaderID  uint64
+}
+
+func (e *Engine) LeaderUpdated(info raftio.LeaderInfo) {
+	e.eventsCh <- leaderUpdated{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+		Term:      info.Term,
+		LeaderID:  info.LeaderID,
+	}
+}
+
+type nodeHostShuttingDown struct{}
+
+func (e *Engine) NodeHostShuttingDown() {
+	e.eventsCh <- nodeHostShuttingDown{}
+}
+
+type nodeUnloaded struct {
+	ShardID   uint64
+	ReplicaID uint64
+}
+
+func (e *Engine) NodeUnloaded(info raftio.NodeInfo) {
+	e.eventsCh <- nodeUnloaded{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+	}
+}
+
+type nodeDeleted struct {
+	ShardID   uint64
+	ReplicaID uint64
+}
+
+func (e *Engine) NodeDeleted(info raftio.NodeInfo) {
+	e.eventsCh <- nodeDeleted{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+	}
+}
+
+type nodeReady struct {
+	ShardID   uint64
+	ReplicaID uint64
+}
+
+func (e *Engine) NodeReady(info raftio.NodeInfo) {
+	e.eventsCh <- nodeReady{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+	}
+}
+
+type membershipChanged struct {
+	ShardID   uint64
+	ReplicaID uint64
+}
+
+func (e *Engine) MembershipChanged(info raftio.NodeInfo) {
+	e.eventsCh <- membershipChanged{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+	}
+}
+
+type connectionEstablished struct {
+	Address            string
+	SnapshotConnection bool
+}
+
+func (e *Engine) ConnectionEstablished(info raftio.ConnectionInfo) {
+	e.eventsCh <- connectionEstablished{
+		Address:            info.Address,
+		SnapshotConnection: info.SnapshotConnection,
+	}
+}
+
+type connectionFailed struct {
+	Address            string
+	SnapshotConnection bool
+}
+
+func (e *Engine) ConnectionFailed(info raftio.ConnectionInfo) {
+	e.eventsCh <- connectionFailed{
+		Address:            info.Address,
+		SnapshotConnection: info.SnapshotConnection,
+	}
+}
+
+type sendSnapshotStarted struct {
+	ShardID   uint64
+	ReplicaID uint64
+	From      uint64
+	Index     uint64
+}
+
+func (e *Engine) SendSnapshotStarted(info raftio.SnapshotInfo) {
+	e.eventsCh <- sendSnapshotStarted{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+		From:      info.From,
+		Index:     info.Index,
+	}
+}
+
+type sendSnapshotCompleted struct {
+	ShardID   uint64
+	ReplicaID uint64
+	From      uint64
+	Index     uint64
+}
+
+func (e *Engine) SendSnapshotCompleted(info raftio.SnapshotInfo) {
+	e.eventsCh <- sendSnapshotCompleted{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+		From:      info.From,
+		Index:     info.Index,
+	}
+}
+
+type sendSnapshotAborted struct {
+	ShardID   uint64
+	ReplicaID uint64
+	From      uint64
+	Index     uint64
+}
+
+func (e *Engine) SendSnapshotAborted(info raftio.SnapshotInfo) {
+	e.eventsCh <- sendSnapshotAborted{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+		From:      info.From,
+		Index:     info.Index,
+	}
+}
+
+type snapshotReceived struct {
+	ShardID   uint64
+	ReplicaID uint64
+	From      uint64
+	Index     uint64
+}
+
+func (e *Engine) SnapshotReceived(info raftio.SnapshotInfo) {
+	e.eventsCh <- snapshotReceived{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+		From:      info.From,
+		Index:     info.Index,
+	}
+}
+
+type snapshotRecovered struct {
+	ShardID   uint64
+	ReplicaID uint64
+	From      uint64
+	Index     uint64
+}
+
+func (e *Engine) SnapshotRecovered(info raftio.SnapshotInfo) {
+	e.eventsCh <- snapshotRecovered{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+		From:      info.From,
+		Index:     info.Index,
+	}
+}
+
+type snapshotCreated struct {
+	ShardID   uint64
+	ReplicaID uint64
+	From      uint64
+	Index     uint64
+}
+
+func (e *Engine) SnapshotCreated(info raftio.SnapshotInfo) {
+	e.eventsCh <- snapshotCreated{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+		From:      info.From,
+		Index:     info.Index,
+	}
+}
+
+type snapshotCompacted struct {
+	ShardID   uint64
+	ReplicaID uint64
+	From      uint64
+	Index     uint64
+}
+
+func (e *Engine) SnapshotCompacted(info raftio.SnapshotInfo) {
+	e.eventsCh <- snapshotCompacted{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+		From:      info.From,
+		Index:     info.Index,
+	}
+}
+
+type logCompacted struct {
+	ShardID   uint64
+	ReplicaID uint64
+}
+
+func (e *Engine) LogCompacted(info raftio.EntryInfo) {
+	e.eventsCh <- logCompacted{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+	}
+}
+
+type logDBCompacted struct {
+	ShardID   uint64
+	ReplicaID uint64
+}
+
+func (e *Engine) LogDBCompacted(info raftio.EntryInfo) {
+	e.eventsCh <- logDBCompacted{
+		ShardID:   info.ShardID,
+		ReplicaID: info.ReplicaID,
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* server should now provide more concise errors when failing to start
* there was a race-condition in handling the Raft events, those are now serialised over channel

## Related Issue

NA

## Motivation and Context

It is a continuation of effort to provide better experience when trying out regatta, it should be easier to debug startup issues as well as to understand the server output.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
