### PR TITLE
add: improve server error reporting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,13 @@ nav_order: 999
 
 # Changelog
 
-## v0.4.0 (unreleased)
+## v0.4.1 (unreleased)
+
+### Improvements
+* Server now reports transient errors for requests that could be potentially retried as `codes.Unavailable`.
+
+---
+## v0.4.0
 
 ### Breaking changes
 * Remove maintenance server port, the API is now available on standard API port. It could still though be secured by a separate API token.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ nav_order: 999
 ### Improvements
 * Server now reports transient errors for requests that could be potentially retried as `codes.Unavailable`.
 
+### Bugfixes
+* Fixed the default timeout of `KV/IterateRange` operation.
+
+
 ---
 ## v0.4.0
 

--- a/regattaserver/kv.go
+++ b/regattaserver/kv.go
@@ -50,7 +50,10 @@ func (s *KVServer) Range(ctx context.Context, req *regattapb.RangeRequest) (*reg
 		if errors.Is(err, serrors.ErrTableNotFound) {
 			return nil, status.Error(codes.NotFound, "table not found")
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		if serrors.IsSafeToRetry(err) {
+			return nil, status.Error(codes.Unavailable, err.Error())
+		}
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return val, nil
 }
@@ -85,7 +88,10 @@ func (s *KVServer) IterateRange(req *regattapb.RangeRequest, srv regattapb.KV_It
 		if errors.Is(err, serrors.ErrTableNotFound) {
 			return status.Error(codes.NotFound, "table not found")
 		}
-		return status.Error(codes.Internal, err.Error())
+		if serrors.IsSafeToRetry(err) {
+			return status.Error(codes.Unavailable, err.Error())
+		}
+		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 	pull, stop := iter.Pull(r)
 	defer stop()
@@ -120,7 +126,10 @@ func (s *KVServer) Put(ctx context.Context, req *regattapb.PutRequest) (*regatta
 		if errors.Is(err, serrors.ErrTableNotFound) {
 			return nil, status.Error(codes.NotFound, "table not found")
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		if serrors.IsSafeToRetry(err) {
+			return nil, status.Error(codes.Unavailable, err.Error())
+		}
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return r, nil
 }
@@ -140,7 +149,10 @@ func (s *KVServer) DeleteRange(ctx context.Context, req *regattapb.DeleteRangeRe
 		if errors.Is(err, serrors.ErrTableNotFound) {
 			return nil, status.Error(codes.NotFound, "table not found")
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		if serrors.IsSafeToRetry(err) {
+			return nil, status.Error(codes.Unavailable, err.Error())
+		}
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return r, nil
 }
@@ -159,7 +171,10 @@ func (s *KVServer) Txn(ctx context.Context, req *regattapb.TxnRequest) (*regatta
 		if errors.Is(err, serrors.ErrTableNotFound) {
 			return nil, status.Error(codes.NotFound, "table not found")
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		if serrors.IsSafeToRetry(err) {
+			return nil, status.Error(codes.Unavailable, err.Error())
+		}
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return r, nil
 }

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -111,7 +111,7 @@ func (e *Engine) IterateRange(ctx context.Context, req *regattapb.RangeRequest) 
 	if err != nil {
 		return nil, err
 	}
-	it, err := t.Iterator(ctx, req)
+	it, err := withDefaultTimeout(ctx, req, t.Iterator)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/errors/errors.go
+++ b/storage/errors/errors.go
@@ -4,11 +4,17 @@ package errors
 
 import (
 	"errors"
+
+	"github.com/lni/dragonboat/v4"
 )
 
+// IsSafeToRetry returns true for transient errors
+// for operations that client could attempt to retry using the same arguments.
+func IsSafeToRetry(err error) bool {
+	return dragonboat.IsTempError(err)
+}
+
 var (
-	// ErrKeyNotFound returned when the key is not found.
-	ErrKeyNotFound = errors.New("key not found")
 	// ErrTableNotFound returned when the table is not found.
 	ErrTableNotFound = errors.New("table not found")
 	// ErrEmptyKey returned when the key is not provided.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use proper GRPC codes for various API error responses.

## Motivation and Context

To be able to distinguish the errors which are safe to retry on and which are not client side.

## How Has This Been Tested?

UTs, ITs
