### PR TITLE
feature: follower writes

### DIFF
--- a/cmd/follower.go
+++ b/cmd/follower.go
@@ -197,11 +197,7 @@ func follower(_ *cobra.Command, _ []string) error {
 			if err != nil {
 				return fmt.Errorf("failed to create API server: %w", err)
 			}
-			fkv := regattaserver.NewForwardingKVServer(engine, regattapb.NewKVClient(conn), nQueue)
-			defer func() {
-				_ = conn.Close()
-			}()
-			regattapb.RegisterKVServer(regatta, fkv)
+			regattapb.RegisterKVServer(regatta, regattaserver.NewForwardingKVServer(engine, regattapb.NewKVClient(conn), nQueue))
 			regattapb.RegisterClusterServer(regatta, &regattaserver.ClusterServer{
 				Cluster: engine,
 				Config:  viperConfigReader,

--- a/cmd/follower.go
+++ b/cmd/follower.go
@@ -108,6 +108,11 @@ func follower(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to parse raft.logdb: %w", err)
 	}
 
+	nQueue := storage.NewNotificationQueue()
+	go nQueue.Run()
+	defer func() {
+		_ = nQueue.Close()
+	}()
 	engine, err := storage.New(storage.Config{
 		Log:                 engineLog.Sugar(),
 		ClientAddress:       viper.GetString("api.advertise-address"),
@@ -129,16 +134,17 @@ func follower(_ *cobra.Command, _ []string) error {
 			NodeName:         viper.GetString("memberlist.node-name"),
 		},
 		Table: storage.TableConfig{
-			FS:                 vfs.Default,
-			ElectionRTT:        viper.GetUint64("raft.election-rtt"),
-			HeartbeatRTT:       viper.GetUint64("raft.heartbeat-rtt"),
-			SnapshotEntries:    viper.GetUint64("raft.snapshot-entries"),
-			CompactionOverhead: viper.GetUint64("raft.compaction-overhead"),
-			MaxInMemLogSize:    viper.GetUint64("raft.max-in-mem-log-size"),
-			DataDir:            viper.GetString("raft.state-machine-dir"),
-			RecoveryType:       toRecoveryType(viper.GetString("raft.snapshot-recovery-type")),
-			BlockCacheSize:     viper.GetInt64("storage.block-cache-size"),
-			TableCacheSize:     viper.GetInt("storage.table-cache-size"),
+			FS:                   vfs.Default,
+			ElectionRTT:          viper.GetUint64("raft.election-rtt"),
+			HeartbeatRTT:         viper.GetUint64("raft.heartbeat-rtt"),
+			SnapshotEntries:      viper.GetUint64("raft.snapshot-entries"),
+			CompactionOverhead:   viper.GetUint64("raft.compaction-overhead"),
+			MaxInMemLogSize:      viper.GetUint64("raft.max-in-mem-log-size"),
+			DataDir:              viper.GetString("raft.state-machine-dir"),
+			RecoveryType:         toRecoveryType(viper.GetString("raft.snapshot-recovery-type")),
+			BlockCacheSize:       viper.GetInt64("storage.block-cache-size"),
+			TableCacheSize:       viper.GetInt("storage.table-cache-size"),
+			AppliedIndexListener: nQueue.Notify,
 		},
 		Meta: storage.MetaConfig{
 			ElectionRTT:        viper.GetUint64("raft.election-rtt"),
@@ -158,15 +164,14 @@ func follower(_ *cobra.Command, _ []string) error {
 	defer engine.Close()
 
 	// Replication
+	conn, err := createReplicationConn()
+	defer func() {
+		_ = conn.Close()
+	}()
+	if err != nil {
+		return fmt.Errorf("cannot create replication conn: %w", err)
+	}
 	{
-		conn, err := createReplicationConn()
-		defer func() {
-			_ = conn.Close()
-		}()
-		if err != nil {
-			return fmt.Errorf("cannot create replication conn: %w", err)
-		}
-
 		d := replication.NewManager(engine.Manager, engine.NodeHost, conn, replication.Config{
 			ReconcileInterval: viper.GetDuration("replication.reconcile-interval"),
 			Workers: replication.WorkerConfig{
@@ -192,11 +197,11 @@ func follower(_ *cobra.Command, _ []string) error {
 			if err != nil {
 				return fmt.Errorf("failed to create API server: %w", err)
 			}
-			regattapb.RegisterKVServer(regatta, &regattaserver.ReadonlyKVServer{
-				KVServer: regattaserver.KVServer{
-					Storage: engine,
-				},
-			})
+			fkv := regattaserver.NewForwardingKVServer(engine, regattapb.NewKVClient(conn), nQueue)
+			defer func() {
+				_ = conn.Close()
+			}()
+			regattapb.RegisterKVServer(regatta, fkv)
 			regattapb.RegisterClusterServer(regatta, &regattaserver.ClusterServer{
 				Cluster: engine,
 				Config:  viperConfigReader,

--- a/cmd/leader.go
+++ b/cmd/leader.go
@@ -226,6 +226,7 @@ func leader(_ *cobra.Command, _ []string) error {
 			)
 			regattapb.RegisterMetadataServer(replication, &regattaserver.MetadataServer{Tables: engine})
 			regattapb.RegisterSnapshotServer(replication, &regattaserver.SnapshotServer{Tables: engine})
+			regattapb.RegisterKVServer(replication, &regattaserver.KVServer{Storage: engine})
 			regattapb.RegisterLogServer(replication, ls)
 			// Start server
 			go func() {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/benbjohnson/clock v1.3.5
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cockroachdb/pebble v0.0.0-20221207173255-0f086d933dac
+	github.com/google/uuid v1.4.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/memberlist v0.5.0
@@ -48,14 +49,13 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/envoyproxy/protoc-gen-validate v1.0.2 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/getsentry/sentry-go v0.25.0 // indirect
+	github.com/getsentry/sentry-go v0.26.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
-	github.com/google/uuid v1.4.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
@@ -64,11 +64,13 @@ require (
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
+	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lni/goutils v1.4.0 // indirect
+	github.com/lyft/protoc-gen-star/v2 v2.0.3 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/miekg/dns v1.1.56 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
+github.com/envoyproxy/protoc-gen-validate v1.0.4 h1:gVPz/FMfvh57HdSJQyvBtF00j8JU4zdyUgIUNhlgg0A=
+github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -106,6 +108,8 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/getsentry/sentry-go v0.25.0 h1:q6Eo+hS+yoJlTO3uu/azhQadsD8V+jQn2D8VvX1eOyI=
 github.com/getsentry/sentry-go v0.25.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go v0.26.0 h1:IX3++sF6/4B5JcevhdZfdKIHfyvMmAq/UnqcyT2H6mA=
+github.com/getsentry/sentry-go v0.26.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9/go.mod h1:106OIgooyS7OzLDOpUGgm9fA3bQENb/cFSyyBmMoJDs=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
@@ -207,6 +211,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
@@ -257,6 +263,8 @@ github.com/lni/goutils v1.4.0 h1:e1tNN+4zsbTpNvhG5cxirkH9Pdz96QAZ2j6+5tmjvqg=
 github.com/lni/goutils v1.4.0/go.mod h1:LIHvF0fflR+zyXUQFQOiHPpKANf3UIr7DFIv5CBPOoU=
 github.com/lni/vfs v0.2.1-0.20220616104132-8852fd867376 h1:jX9CoRWNPwrZ2yY3RJFTSwa49qDQqtXglrCByGdQGZg=
 github.com/lni/vfs v0.2.1-0.20220616104132-8852fd867376/go.mod h1:LOatfyR8Xeej1jbXybwYGVfCccR0u+BQRG9xg7BD7xo=
+github.com/lyft/protoc-gen-star/v2 v2.0.3 h1:/3+/2sWyXeMLzKd1bX+ixWKgEMsULrIivpDsuaF441o=
+github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -56,7 +56,7 @@ func New(cfg Config) (*Engine, error) {
 		},
 	)
 	if cfg.LogCacheSize > 0 {
-		e.LogCache = &logreader.ShardCache{ShardCacheSize: cfg.LogCacheSize}
+		e.LogCache = logreader.NewShardCache(cfg.LogCacheSize)
 		e.LogReader = &logreader.Cached{LogQuerier: nh, ShardCache: e.LogCache}
 	} else {
 		e.LogReader = &logreader.Simple{LogQuerier: nh}

--- a/storage/engine_events.go
+++ b/storage/engine_events.go
@@ -17,12 +17,7 @@ func (e *events) dispatchEvents() {
 		switch ev := evt.(type) {
 		case nodeHostShuttingDown:
 			return
-		case leaderUpdated, nodeUnloaded, membershipChanged:
-			e.engine.Cluster.Notify()
-		case nodeReady:
-			if ev.ReplicaID == e.engine.cfg.NodeID && e.engine.LogCache != nil {
-				e.engine.LogCache.NodeReady(ev.ShardID)
-			}
+		case leaderUpdated, nodeUnloaded, membershipChanged, nodeReady:
 			e.engine.Cluster.Notify()
 		case nodeDeleted:
 			if ev.ReplicaID == e.engine.cfg.NodeID && e.engine.LogCache != nil {
@@ -33,7 +28,6 @@ func (e *events) dispatchEvents() {
 			if ev.ReplicaID == e.engine.cfg.NodeID && e.engine.LogCache != nil {
 				e.engine.LogCache.LogCompacted(ev.ShardID)
 			}
-			e.engine.Cluster.Notify()
 		}
 	}
 }

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -1,0 +1,112 @@
+// Copyright JAMF Software, LLC
+
+package storage
+
+import (
+	"cmp"
+	"context"
+	"time"
+
+	"github.com/jamf/regatta/util"
+	"github.com/jamf/regatta/util/heap"
+	"github.com/jamf/regatta/util/iter"
+)
+
+type item struct {
+	ctx      context.Context
+	table    string
+	revision uint64
+	waitCh   chan error
+}
+
+type notification struct {
+	table    string
+	revision uint64
+}
+
+type IndexNotificationQueue struct {
+	items  *util.SyncMap[string, *heap.Heap[*item]]
+	add    chan *item
+	notif  chan notification
+	closed chan struct{}
+}
+
+func NewNotificationQueue() *IndexNotificationQueue {
+	return &IndexNotificationQueue{
+		add:    make(chan *item),
+		notif:  make(chan notification),
+		closed: make(chan struct{}),
+		items: util.NewSyncMap(func(k string) *heap.Heap[*item] {
+			return heap.New(func(e *item, e2 *item) bool { return cmp.Less(e.revision, e2.revision) })
+		}),
+	}
+}
+
+func (q *IndexNotificationQueue) Run() {
+	gc := time.NewTicker(time.Second)
+	defer gc.Stop()
+	for {
+		select {
+		case <-q.closed:
+			return
+		case <-gc.C:
+			iter.Consume(q.items.Values(), func(h *heap.Heap[*item]) {
+				l := h.Len()
+				for i := 0; i < l; i++ {
+					elem := h.Slice[i]
+					if elem.ctx.Err() != nil {
+						// Reorder
+						elem.revision = 0
+					}
+				}
+				h.Fix(0)
+				for i := 0; i < l; i++ {
+					elem := h.Peek()
+					if elem.revision == 0 {
+						h.Pop()
+					} else {
+						break
+					}
+				}
+			})
+		case it := <-q.add:
+			h, _ := q.items.Load(it.table)
+			h.Push(it)
+		case n := <-q.notif:
+			h, _ := q.items.Load(n.table)
+			l := h.Len()
+			for i := 0; i < l; i++ {
+				elem := h.Peek()
+				if elem.ctx.Err() != nil {
+					elem.waitCh <- elem.ctx.Err()
+					h.Pop()
+				} else if elem.revision <= n.revision {
+					close(elem.waitCh)
+					h.Pop()
+				} else {
+					break
+				}
+			}
+		}
+	}
+}
+
+func (q *IndexNotificationQueue) Notify(table string, revision uint64) {
+	q.notif <- notification{table: table, revision: revision}
+}
+
+func (q *IndexNotificationQueue) Close() error {
+	close(q.closed)
+	return nil
+}
+
+func (q *IndexNotificationQueue) Add(ctx context.Context, table string, revision uint64) <-chan error {
+	ch := make(chan error, 1)
+	q.add <- &item{
+		ctx:      ctx,
+		table:    table,
+		revision: revision,
+		waitCh:   ch,
+	}
+	return ch
+}

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -1,0 +1,71 @@
+// Copyright JAMF Software, LLC
+
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationQueue(t *testing.T) {
+	q := NewNotificationQueue()
+	go q.Run()
+	defer q.Close()
+
+	w := q.Add(context.Background(), "foo", 1)
+	require.Empty(t, w)
+	q.Notify("foo", 10)
+	chanelClosed(t, w)
+	w = q.Add(context.Background(), "foo", 5)
+	require.Empty(t, w)
+	q.Notify("foo", 4)
+	require.Empty(t, w)
+	q.Notify("foo", 20)
+	chanelClosed(t, w)
+
+	h, _ := q.items.Load("foo")
+	require.Zero(t, h.Len())
+}
+
+func TestNotificationQueueTimeout(t *testing.T) {
+	q := NewNotificationQueue()
+	go q.Run()
+	defer q.Close()
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	q.Add(ctx, "foo", 1)
+	q.Add(ctx, "foo", 2)
+	q.Add(ctx, "foo", 3)
+	w := q.Add(ctx, "foo", 4)
+	cancel()
+
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-w:
+			return assert.Error(t, err, context.Canceled)
+		default:
+			return false
+		}
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		h, _ := q.items.Load("foo")
+		return assert.Zero(t, h.Len())
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func chanelClosed(t *testing.T, w <-chan error) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		select {
+		case <-w:
+			return true
+		default:
+			return false
+		}
+	}, 10*time.Millisecond, time.Millisecond)
+}

--- a/storage/table/config.go
+++ b/storage/table/config.go
@@ -103,7 +103,8 @@ type TableConfig struct {
 	// TableCacheSize shared table cache size, the cache is used to hold handles to open SSTs.
 	TableCacheSize int
 	// RecoveryType the in-cluster snapshot recovery type.
-	RecoveryType SnapshotRecoveryType
+	RecoveryType         SnapshotRecoveryType
+	AppliedIndexListener func(table string, rev uint64)
 }
 
 type MetaConfig struct {

--- a/storage/table/fsm/fsm_feature_test.go
+++ b/storage/table/fsm/fsm_feature_test.go
@@ -490,14 +490,15 @@ func generateFiles(t *testing.T, version int, inputCommands []*regattapb.Command
 
 func createTestFSM() (*FSM, error) {
 	fsm := &FSM{
-		fs:        vfs.NewMem(),
-		clusterID: 1,
-		nodeID:    1,
-		tableName: "test",
-		dirname:   "/tmp",
-		closed:    false,
-		log:       zap.NewNop().Sugar(),
-		metrics:   newMetrics("test", 1),
+		fs:          vfs.NewMem(),
+		clusterID:   1,
+		nodeID:      1,
+		tableName:   "test",
+		dirname:     "/tmp",
+		closed:      false,
+		log:         zap.NewNop().Sugar(),
+		metrics:     newMetrics("test", 1),
+		appliedFunc: func(applied uint64) {},
 	}
 
 	db, err := rp.OpenDB(fsm.dirname, rp.WithFS(fsm.fs))

--- a/storage/table/fsm/fsm_test.go
+++ b/storage/table/fsm/fsm_test.go
@@ -80,12 +80,13 @@ func TestSM_Open(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := require.New(t)
 			p := &FSM{
-				fs:        vfs.NewMem(),
-				clusterID: tt.fields.clusterID,
-				nodeID:    tt.fields.nodeID,
-				dirname:   tt.fields.dirname,
-				log:       zap.NewNop().Sugar(),
-				metrics:   newMetrics(testTable, tt.fields.clusterID),
+				fs:          vfs.NewMem(),
+				clusterID:   tt.fields.clusterID,
+				nodeID:      tt.fields.nodeID,
+				dirname:     tt.fields.dirname,
+				log:         zap.NewNop().Sugar(),
+				metrics:     newMetrics(testTable, tt.fields.clusterID),
+				appliedFunc: func(applied uint64) {},
 			}
 			_, err := p.Open(nil)
 			if tt.wantErr {
@@ -103,12 +104,13 @@ func TestFSM_ReOpen(t *testing.T) {
 	fs := vfs.NewMem()
 	const testIndex uint64 = 10
 	p := &FSM{
-		fs:        fs,
-		clusterID: 1,
-		nodeID:    1,
-		dirname:   "/tmp/dir",
-		log:       zap.NewNop().Sugar(),
-		metrics:   newMetrics(testTable, 1),
+		fs:          fs,
+		clusterID:   1,
+		nodeID:      1,
+		dirname:     "/tmp/dir",
+		log:         zap.NewNop().Sugar(),
+		metrics:     newMetrics(testTable, 1),
+		appliedFunc: func(applied uint64) {},
 	}
 
 	t.Log("open FSM")
@@ -734,12 +736,13 @@ func equalResult(t *testing.T, want sm.Result, got sm.Result) {
 
 func emptySM() *FSM {
 	p := &FSM{
-		fs:        vfs.NewMem(),
-		clusterID: 1,
-		nodeID:    1,
-		dirname:   "/tmp/tst",
-		log:       zap.NewNop().Sugar(),
-		metrics:   newMetrics(testTable, 1),
+		fs:          vfs.NewMem(),
+		clusterID:   1,
+		nodeID:      1,
+		dirname:     "/tmp/tst",
+		log:         zap.NewNop().Sugar(),
+		metrics:     newMetrics(testTable, 1),
+		appliedFunc: func(applied uint64) {},
 	}
 	_, err := p.Open(nil)
 	if err != nil {
@@ -777,12 +780,13 @@ func filledSM() *FSM {
 		})
 	}
 	p := &FSM{
-		fs:        vfs.NewMem(),
-		clusterID: 1,
-		nodeID:    1,
-		dirname:   "/tmp/tst",
-		log:       zap.NewNop().Sugar(),
-		metrics:   newMetrics(testTable, 1),
+		fs:          vfs.NewMem(),
+		clusterID:   1,
+		nodeID:      1,
+		dirname:     "/tmp/tst",
+		log:         zap.NewNop().Sugar(),
+		metrics:     newMetrics(testTable, 1),
+		appliedFunc: func(applied uint64) {},
 	}
 	_, err := p.Open(nil)
 	if err != nil {
@@ -811,12 +815,13 @@ func filledLargeValuesSM() *FSM {
 		}
 	}
 	p := &FSM{
-		fs:        vfs.NewMem(),
-		clusterID: 1,
-		nodeID:    1,
-		dirname:   "/tmp/tst",
-		log:       zap.NewNop().Sugar(),
-		metrics:   newMetrics(testTable, 1),
+		fs:          vfs.NewMem(),
+		clusterID:   1,
+		nodeID:      1,
+		dirname:     "/tmp/tst",
+		log:         zap.NewNop().Sugar(),
+		metrics:     newMetrics(testTable, 1),
+		appliedFunc: func(applied uint64) {},
 	}
 	_, err := p.Open(nil)
 	if err != nil {
@@ -831,12 +836,13 @@ func filledLargeValuesSM() *FSM {
 
 func filledIndexOnlySM() *FSM {
 	p := &FSM{
-		fs:        vfs.NewMem(),
-		clusterID: 1,
-		nodeID:    1,
-		dirname:   "/tmp/tst",
-		log:       zap.NewNop().Sugar(),
-		metrics:   newMetrics(testTable, 1),
+		fs:          vfs.NewMem(),
+		clusterID:   1,
+		nodeID:      1,
+		dirname:     "/tmp/tst",
+		log:         zap.NewNop().Sugar(),
+		metrics:     newMetrics(testTable, 1),
+		appliedFunc: func(applied uint64) {},
 	}
 	_, err := p.Open(nil)
 	if err != nil {

--- a/storage/table/fsm/metrics_test.go
+++ b/storage/table/fsm/metrics_test.go
@@ -15,12 +15,13 @@ import (
 
 func TestFSM_Metrics(t *testing.T) {
 	p := &FSM{
-		fs:        vfs.NewMem(),
-		clusterID: 1,
-		nodeID:    1,
-		dirname:   "/tmp",
-		log:       zap.NewNop().Sugar(),
-		metrics:   newMetrics(testTable, 1),
+		fs:          vfs.NewMem(),
+		clusterID:   1,
+		nodeID:      1,
+		dirname:     "/tmp",
+		log:         zap.NewNop().Sugar(),
+		metrics:     newMetrics(testTable, 1),
+		appliedFunc: func(applied uint64) {},
 	}
 	_, _ = p.Open(nil)
 	inFile, err := os.Open(path.Join("testdata", "metrics"))

--- a/storage/table/manager.go
+++ b/storage/table/manager.go
@@ -495,14 +495,22 @@ func (m *Manager) startTable(name string, id uint64) error {
 		return m.nh.StartOnDiskReplica(
 			map[uint64]dragonboat.Target{},
 			false,
-			fsm.New(name, m.cfg.Table.DataDir, m.cfg.Table.FS, m.blockCache, m.tableCache, fsm.SnapshotRecoveryType(m.cfg.Table.RecoveryType)),
+			fsm.New(name, m.cfg.Table.DataDir, m.cfg.Table.FS, m.blockCache, m.tableCache, fsm.SnapshotRecoveryType(m.cfg.Table.RecoveryType), func(applied uint64) {
+				if m.cfg.Table.AppliedIndexListener != nil {
+					m.cfg.Table.AppliedIndexListener(name, applied)
+				}
+			}),
 			tableRaftConfig(m.cfg.NodeID, id, m.cfg.Table),
 		)
 	}
 	return m.nh.StartOnDiskReplica(
 		m.members,
 		false,
-		fsm.New(name, m.cfg.Table.DataDir, m.cfg.Table.FS, m.blockCache, m.tableCache, fsm.SnapshotRecoveryType(m.cfg.Table.RecoveryType)),
+		fsm.New(name, m.cfg.Table.DataDir, m.cfg.Table.FS, m.blockCache, m.tableCache, fsm.SnapshotRecoveryType(m.cfg.Table.RecoveryType), func(applied uint64) {
+			if m.cfg.Table.AppliedIndexListener != nil {
+				m.cfg.Table.AppliedIndexListener(name, applied)
+			}
+		}),
 		tableRaftConfig(m.cfg.NodeID, id, m.cfg.Table),
 	)
 }

--- a/util/heap/heap.go
+++ b/util/heap/heap.go
@@ -1,0 +1,109 @@
+// Copyright JAMF Software, LLC
+
+package heap
+
+type Heap[E any] struct {
+	Slice []E
+	Less  func(E, E) bool
+}
+
+func New[E any](less func(E, E) bool, items ...E) *Heap[E] {
+	h := &Heap[E]{
+		Slice: items,
+		Less:  less,
+	}
+	n := len(items)
+	for i := n/2 - 1; i >= 0; i-- {
+		h.down(i, n)
+	}
+	return h
+}
+
+func (h *Heap[E]) Peek() E {
+	if len(h.Slice) == 0 {
+		panic("empty slice")
+	}
+	return h.Slice[0]
+}
+
+func (h *Heap[E]) Push(item E) {
+	h.Slice = append(h.Slice, item)
+	h.up(len(h.Slice) - 1)
+}
+
+func (h *Heap[E]) Pop() E {
+	if len(h.Slice) == 0 {
+		panic("empty slice")
+	}
+	n := len(h.Slice) - 1
+	h.swap(0, n)
+	h.down(0, n)
+	return h.zpop()
+}
+
+func (h *Heap[E]) Remove(i int) E {
+	n := len(h.Slice) - 1
+	if n != i {
+		h.swap(i, n)
+		if !h.down(i, n) {
+			h.up(i)
+		}
+	}
+	return h.zpop()
+}
+
+func (h *Heap[E]) Len() int {
+	return len(h.Slice)
+}
+
+func (h *Heap[E]) Fix(i int) {
+	if i < 0 {
+		return
+	}
+	if !h.down(i, len(h.Slice)) {
+		h.up(i)
+	}
+}
+
+func (h *Heap[E]) up(j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || !h.Less(h.Slice[j], h.Slice[i]) {
+			break
+		}
+		h.swap(i, j)
+		j = i
+	}
+}
+
+func (h *Heap[E]) down(i0 int, n int) bool {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 { // j1 < 0 after int overflow
+			break
+		}
+		j := j1 // left child
+		if j2 := j1 + 1; j2 < n && h.Less(h.Slice[j2], h.Slice[j1]) {
+			j = j2 // = 2*i + 2  // right child
+		}
+		if !h.Less(h.Slice[j], h.Slice[i]) {
+			break
+		}
+		h.swap(i, j)
+		i = j
+	}
+	return i > i0
+}
+
+func (h *Heap[E]) swap(i, j int) {
+	h.Slice[i], h.Slice[j] = h.Slice[j], h.Slice[i]
+}
+
+func (h *Heap[E]) zpop() E {
+	var zero E
+	e0 := h.Slice[len(h.Slice)-1]
+	h.Slice[len(h.Slice)-1] = zero
+	h.Slice = h.Slice[:len(h.Slice)-1]
+	return e0
+}

--- a/util/heap/heap_test.go
+++ b/util/heap/heap_test.go
@@ -1,0 +1,195 @@
+// Copyright JAMF Software, LLC
+
+package heap
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func newHeap() *Heap[int] {
+	return &Heap[int]{
+		Less: func(i, j int) bool {
+			return i < j
+		},
+	}
+}
+
+func verify[T any](t *testing.T, h *Heap[T], i int) {
+	t.Helper()
+	n := h.Len()
+	j1 := 2*i + 1
+	j2 := 2*i + 2
+	if j1 < n {
+		if h.Less(h.Slice[j1], h.Slice[i]) {
+			t.Errorf("heap invariant invalidated [%d] = %v > [%d] = %v", i, h.Slice[i], j1, h.Slice[j1])
+			return
+		}
+		verify(t, h, j1)
+	}
+	if j2 < n {
+		if h.Less(h.Slice[j2], h.Slice[i]) {
+			t.Errorf("heap invariant invalidated [%d] = %v > [%d] = %v", i, h.Slice[i], j1, h.Slice[j2])
+			return
+		}
+		verify(t, h, j2)
+	}
+}
+
+func TestInit0(t *testing.T) {
+	h := newHeap()
+	for i := 20; i > 0; i-- {
+		h.Push(0) // all elements are the same
+	}
+	verify(t, h, 0)
+
+	for i := 1; h.Len() > 0; i++ {
+		x := h.Pop()
+		verify(t, h, 0)
+		if x != 0 {
+			t.Errorf("%d.th pop got %d; want %d", i, x, 0)
+		}
+	}
+}
+
+func TestInit1(t *testing.T) {
+	h := newHeap()
+	for i := 20; i > 0; i-- {
+		h.Push(i) // all elements are different
+	}
+	verify(t, h, 0)
+
+	for i := 1; h.Len() > 0; i++ {
+		x := h.Pop()
+		verify(t, h, 0)
+		if x != i {
+			t.Errorf("%d.th pop got %d; want %d", i, x, i)
+		}
+	}
+}
+
+func Test(t *testing.T) {
+	h := newHeap()
+	verify(t, h, 0)
+
+	for i := 20; i > 10; i-- {
+		h.Push(i)
+	}
+	verify(t, h, 0)
+
+	for i := 10; i > 0; i-- {
+		h.Push(i)
+		verify(t, h, 0)
+	}
+
+	for i := 1; h.Len() > 0; i++ {
+		x := h.Pop()
+		if i < 20 {
+			h.Push(20 + i)
+		}
+		verify(t, h, 0)
+		if x != i {
+			t.Errorf("%d.th pop got %d; want %d", i, x, i)
+		}
+	}
+}
+
+func TestRemove0(t *testing.T) {
+	h := newHeap()
+	for i := 0; i < 10; i++ {
+		h.Push(i)
+	}
+	verify(t, h, 0)
+
+	for h.Len() > 0 {
+		i := h.Len() - 1
+		x := h.Remove(i)
+		if x != i {
+			t.Errorf("Remove(%d) got %d; want %d", i, x, i)
+		}
+		verify(t, h, 0)
+	}
+}
+
+func TestRemove1(t *testing.T) {
+	h := newHeap()
+	for i := 0; i < 10; i++ {
+		h.Push(i)
+	}
+	verify(t, h, 0)
+
+	for i := 0; h.Len() > 0; i++ {
+		x := h.Remove(0)
+		if x != i {
+			t.Errorf("Remove(0) got %d; want %d", x, i)
+		}
+		verify(t, h, 0)
+	}
+}
+
+func TestRemove2(t *testing.T) {
+	N := 10
+
+	h := newHeap()
+	for i := 0; i < N; i++ {
+		h.Push(i)
+	}
+	verify(t, h, 0)
+
+	m := make(map[int]bool)
+	for h.Len() > 0 {
+		m[h.Remove((h.Len()-1)/2)] = true
+		verify(t, h, 0)
+	}
+
+	if len(m) != N {
+		t.Errorf("len(m) = %d; want %d", len(m), N)
+	}
+	for i := 0; i < len(m); i++ {
+		if !m[i] {
+			t.Errorf("m[%d] doesn't exist", i)
+		}
+	}
+}
+
+func BenchmarkDup(b *testing.B) {
+	const n = 10000
+	h := newHeap()
+	h.Slice = make([]int, 0, n)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < n; j++ {
+			h.Push(0) // all elements are the same
+		}
+		for h.Len() > 0 {
+			h.Pop()
+		}
+	}
+}
+
+func TestFix(t *testing.T) {
+	h := newHeap()
+	verify(t, h, 0)
+
+	for i := 200; i > 0; i -= 10 {
+		h.Push(i)
+	}
+	verify(t, h, 0)
+
+	if h.Slice[0] != 10 {
+		t.Fatalf("Expected head to be 10, was %d", h.Slice[0])
+	}
+	h.Slice[0] = 210
+	h.Fix(0)
+	verify(t, h, 0)
+
+	for i := 100; i > 0; i-- {
+		elem := rand.Intn(h.Len())
+		if i&1 == 0 {
+			h.Slice[elem] *= 2
+		} else {
+			h.Slice[elem] /= 2
+		}
+		h.Fix(elem)
+		verify(t, h, 0)
+	}
+}

--- a/util/iter/iter.go
+++ b/util/iter/iter.go
@@ -82,3 +82,15 @@ func Pull[T any](seq Seq[T]) (iter func() (T, bool), stop func()) {
 			<-yield
 		})
 }
+
+func Contains[T comparable](seq Seq[T], item T) bool {
+	found := false
+	seq(func(t T) bool {
+		if t == item {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/util/sync.go
+++ b/util/sync.go
@@ -4,38 +4,55 @@ package util
 
 import (
 	"sync"
+
+	"github.com/jamf/regatta/util/iter"
 )
 
 type SyncMap[K comparable, V any] struct {
-	m   map[K]V
-	mtx sync.RWMutex
+	m           map[K]V
+	mtx         sync.RWMutex
+	defaultFunc func(K) V
+}
+
+func NewSyncMap[K comparable, V any](defaulter func(K) V) *SyncMap[K, V] {
+	return &SyncMap[K, V]{m: make(map[K]V), defaultFunc: defaulter}
+}
+
+func (s *SyncMap[K, V]) Values() iter.Seq[V] {
+	s.mtx.RLock()
+	s.mtx.RUnlock()
+	return func(yield func(V) bool) {
+		for _, v := range s.m {
+			if !yield(v) {
+				break
+			}
+		}
+	}
 }
 
 func (s *SyncMap[K, V]) Load(key K) (V, bool) {
 	s.mtx.RLock()
-	defer s.mtx.RUnlock()
-	if s.m == nil {
-		return *new(V), false
-	}
 	v, ok := s.m[key]
+	if !ok && s.defaultFunc != nil {
+		s.mtx.RUnlock()
+		s.mtx.Lock()
+		defer s.mtx.Unlock()
+		s.m[key] = s.defaultFunc(key)
+		return s.m[key], true
+	}
+	s.mtx.RUnlock()
 	return v, ok
 }
 
 func (s *SyncMap[K, V]) Store(key K, val V) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	if s.m == nil {
-		s.m = make(map[K]V)
-	}
 	s.m[key] = val
 }
 
 func (s *SyncMap[K, V]) ComputeIfAbsent(key K, valFunc func(K) V) V {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	if s.m == nil {
-		s.m = make(map[K]V)
-	}
 	v, ok := s.m[key]
 	if !ok {
 		v = valFunc(key)

--- a/util/sync_test.go
+++ b/util/sync_test.go
@@ -23,7 +23,8 @@ func TestSyncMap_ComputeIfAbsent(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "compute missing key",
+			name:   "compute missing key",
+			fields: fields{m: map[string]string{}},
 			args: args{
 				key: "key",
 				valFunc: func(s string) string {
@@ -151,7 +152,8 @@ func TestSyncMap_Store(t *testing.T) {
 		assert func(*testing.T, *SyncMap[string, string])
 	}{
 		{
-			name: "store into empty map",
+			name:   "store into empty map",
+			fields: fields{m: map[string]string{}},
 			args: args{
 				key: "key",
 				val: "value",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implements "backward" replication and in-turn follower write API. Follower clusters could write using Put, DeleteRange and Txn Ops. The call will be proxied to the leader cluster and awaited for the propagation of the revision in which it was written at the leader.

## Related Issue
Fixes: #112 
Fixes: #113

## Motivation and Context

Change necessary to provide ability to replicate data in between followers.

> [!IMPORTANT]
> In this version the latency of the follower write is about  `0.9 * replication.poll-interval`. (read pretty high) The followup to this PR should improve that number dramatically.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
