### PR TITLE
feat: follower write API part2

### DIFF
--- a/cmd/follower.go
+++ b/cmd/follower.go
@@ -172,7 +172,7 @@ func follower(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("cannot create replication conn: %w", err)
 	}
 	{
-		d := replication.NewManager(engine.Manager, engine.NodeHost, conn, replication.Config{
+		d := replication.NewManager(engine, conn, replication.Config{
 			ReconcileInterval: viper.GetDuration("replication.reconcile-interval"),
 			Workers: replication.WorkerConfig{
 				PollInterval:        viper.GetDuration("replication.poll-interval"),

--- a/cmd/leader.go
+++ b/cmd/leader.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -156,11 +157,11 @@ func leader(_ *cobra.Command, _ []string) error {
 	defer engine.Close()
 
 	go func() {
-		if err := engine.WaitUntilReady(); err != nil {
-			log.Infof("table manager failed to start: %v", err)
+		if err := engine.WaitUntilReady(context.Background()); err != nil {
+			log.Infof("engine failed to start: %v", err)
 			return
 		}
-		log.Info("table manager started")
+		log.Info("engine started")
 		tNames := viper.GetStringSlice("tables.names")
 		for _, table := range tNames {
 			log.Debugf("creating table %s", table)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 999
 ## v0.5.0 (unreleased)
 
 ### Highlights
+#### Follower to leader replication
+* The write API (Put, DeleteRange, Txn) is now available on leader cluster nodes as well.
+* The API provides read after write guarantee by relying on backpropagation from the leader.
+
 #### Dynamic tables management
 * Tables now could be managed dynamically during the runtime of the server using newly provided `regatta.v1.Tables` API.
 * Tables API could be secured by an API token using `tables.token` configuration value.
@@ -15,6 +19,7 @@ nav_order: 999
 ### Improvements
 * Improve on API allocations when deserializing gRPC messages.
 * Support `zstd` API compression.
+* Removed obsolete table manager cache that could have caused hard to debug race conditions.
 
 ### Deprecations
 * `tables.names` and `tables.delete` configuration values were deprecated and will be removed in future releases.
@@ -22,6 +27,7 @@ nav_order: 999
 ### Bugfixes
 * Proper authentication of `maintenance.v1.Backup/Restore` API endpoint.
 * When table is deleted in the leader cluster the followers will gracefully handle the situation by deleting the table locally and stopping the replication.
+* Fixed potential Engine deadlock when shutting down the server.
 ---
 ## v0.4.1
 

--- a/regattaserver/regattaserver_test.go
+++ b/regattaserver/regattaserver_test.go
@@ -3,6 +3,7 @@
 package regattaserver
 
 import (
+	"context"
 	"io"
 	"net"
 	"testing"
@@ -93,7 +94,7 @@ func newInMemTestEngine(t *testing.T, tables ...string) *storage.Engine {
 	})
 	require.NoError(t, err)
 	require.NoError(t, e.Start())
-	require.NoError(t, e.WaitUntilReady())
+	require.NoError(t, e.WaitUntilReady(context.Background()))
 	for _, tableName := range tables {
 		at, err := e.CreateTable(tableName)
 		require.NoError(t, err)

--- a/replication/backup/backup_test.go
+++ b/replication/backup/backup_test.go
@@ -331,7 +331,7 @@ func newTestEngine(t *testing.T) *storage.Engine {
 	e, err := storage.New(newTestConfig(t))
 	require.NoError(t, err)
 	require.NoError(t, e.Start())
-	require.NoError(t, e.WaitUntilReady())
+	require.NoError(t, e.WaitUntilReady(context.Background()))
 	t.Cleanup(func() {
 		defer func() { recover() }()
 		require.NoError(t, e.Close())

--- a/storage/engine_events.go
+++ b/storage/engine_events.go
@@ -49,7 +49,8 @@ func (e *events) LeaderUpdated(info raftio.LeaderInfo) {
 		ShardID:   info.ShardID,
 		ReplicaID: info.ReplicaID,
 		Term:      info.Term,
-		LeaderID:  info.LeaderID}:
+		LeaderID:  info.LeaderID,
+	}:
 	}
 }
 
@@ -156,7 +157,8 @@ func (e *events) SendSnapshotStarted(info raftio.SnapshotInfo) {
 		ShardID:   info.ShardID,
 		ReplicaID: info.ReplicaID,
 		From:      info.From,
-		Index:     info.Index}:
+		Index:     info.Index,
+	}:
 	}
 }
 
@@ -175,7 +177,8 @@ func (e *events) SendSnapshotCompleted(info raftio.SnapshotInfo) {
 		ShardID:   info.ShardID,
 		ReplicaID: info.ReplicaID,
 		From:      info.From,
-		Index:     info.Index}:
+		Index:     info.Index,
+	}:
 	}
 }
 
@@ -194,7 +197,8 @@ func (e *events) SendSnapshotAborted(info raftio.SnapshotInfo) {
 		ShardID:   info.ShardID,
 		ReplicaID: info.ReplicaID,
 		From:      info.From,
-		Index:     info.Index}:
+		Index:     info.Index,
+	}:
 	}
 }
 
@@ -213,7 +217,8 @@ func (e *events) SnapshotReceived(info raftio.SnapshotInfo) {
 		ShardID:   info.ShardID,
 		ReplicaID: info.ReplicaID,
 		From:      info.From,
-		Index:     info.Index}:
+		Index:     info.Index,
+	}:
 	}
 }
 
@@ -232,7 +237,8 @@ func (e *events) SnapshotRecovered(info raftio.SnapshotInfo) {
 		ShardID:   info.ShardID,
 		ReplicaID: info.ReplicaID,
 		From:      info.From,
-		Index:     info.Index}:
+		Index:     info.Index,
+	}:
 	}
 }
 
@@ -251,7 +257,8 @@ func (e *events) SnapshotCreated(info raftio.SnapshotInfo) {
 		ShardID:   info.ShardID,
 		ReplicaID: info.ReplicaID,
 		From:      info.From,
-		Index:     info.Index}:
+		Index:     info.Index,
+	}:
 	}
 }
 
@@ -270,7 +277,8 @@ func (e *events) SnapshotCompacted(info raftio.SnapshotInfo) {
 		ShardID:   info.ShardID,
 		ReplicaID: info.ReplicaID,
 		From:      info.From,
-		Index:     info.Index}:
+		Index:     info.Index,
+	}:
 	}
 }
 
@@ -285,7 +293,8 @@ func (e *events) LogCompacted(info raftio.EntryInfo) {
 		return
 	case e.eventsCh <- logCompacted{
 		ShardID:   info.ShardID,
-		ReplicaID: info.ReplicaID}:
+		ReplicaID: info.ReplicaID,
+	}:
 	}
 }
 
@@ -300,6 +309,7 @@ func (e *events) LogDBCompacted(info raftio.EntryInfo) {
 		return
 	case e.eventsCh <- logDBCompacted{
 		ShardID:   info.ShardID,
-		ReplicaID: info.ReplicaID}:
+		ReplicaID: info.ReplicaID,
+	}:
 	}
 }

--- a/storage/limiter.go
+++ b/storage/limiter.go
@@ -1,0 +1,169 @@
+// Copyright JAMF Software, LLC
+
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/jamf/regatta/storage/kv"
+)
+
+type burst struct {
+	Tokens   uint64        `json:"a"`
+	Interval time.Duration `json:"i"`
+	ValidTo  time.Time     `json:"v"`
+}
+
+type state struct {
+	Tokens    uint64        `json:"a"`
+	Interval  time.Duration `json:"i"`
+	Remaining uint64        `json:"r"`
+	LastTake  time.Time     `json:"l"`
+	Burst     burst         `json:"b,omitempty"`
+	Ver       uint64        `json:"-"`
+}
+
+type kvLimiter struct {
+	rs    *kv.RaftStore
+	clock clock.Clock
+	mtx   sync.Mutex
+}
+
+func (k *kvLimiter) prefixKey(key string) string {
+	return fmt.Sprintf("ratelimit/%s", key)
+}
+
+func (k *kvLimiter) getState(key string) (state, error) {
+	get, err := k.rs.Get(k.prefixKey(key))
+	s := state{}
+	if err != nil {
+		if errors.Is(err, kv.ErrNotExist) {
+			return s, nil
+		}
+		return s, err
+	}
+	if err := json.Unmarshal([]byte(get.Value), &s); err != nil {
+		return s, err
+	}
+	s.Ver = get.Ver
+	return s, nil
+}
+
+func (k *kvLimiter) setState(key string, new state, version uint64) (state, error) {
+	b, err := json.Marshal(new)
+	if err != nil {
+		return new, err
+	}
+	p, err := k.rs.Set(k.prefixKey(key), string(b), version)
+	if err != nil {
+		return new, err
+	}
+	new.Ver = p.Ver
+	return new, nil
+}
+
+func (k *kvLimiter) WaitFor(ctx context.Context, key string) error {
+	for {
+		_, next, ok, _ := k.Take(key)
+		if ok {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(next.Sub(k.clock.Now())):
+			continue
+		}
+	}
+}
+
+func (k *kvLimiter) Take(key string) (remaining uint64, reset time.Time, ok bool, err error) {
+	k.mtx.Lock()
+	defer k.mtx.Unlock()
+
+	s, err := k.getState(key)
+	if err != nil {
+		return 0, k.clock.Now(), false, err
+	}
+
+	now := k.clock.Now()
+	next := now
+
+	if s.Burst.ValidTo.Before(now) {
+		s.Burst = burst{}
+	}
+
+	if !s.LastTake.IsZero() {
+		fromLast := now.Sub(s.LastTake)
+		if s.Burst.ValidTo.After(now) {
+			next = s.LastTake.Add(s.Burst.Interval)
+			nums := fromLast / s.Burst.Interval
+			if nums > 1 {
+				s.Remaining += s.Burst.Tokens * uint64(nums)
+			}
+		} else {
+			next = s.LastTake.Add(s.Interval)
+			nums := fromLast / s.Interval
+			if nums > 1 {
+				s.Remaining += s.Tokens * uint64(nums)
+			}
+		}
+	}
+
+	if s.Remaining > 0 {
+		s.Remaining -= 1
+		s.LastTake = now
+		news, err := k.setState(key, s, s.Ver)
+		if err != nil {
+			return 0, next, false, err
+		}
+		return news.Remaining, next, true, nil
+	}
+	return s.Remaining, next, false, nil
+}
+
+func (k *kvLimiter) Get(key string) (tokens, remaining uint64, err error) {
+	k.mtx.Lock()
+	defer k.mtx.Unlock()
+
+	s, err := k.getState(key)
+	if err != nil {
+		return 0, 0, err
+	}
+	return s.Tokens, s.Remaining, nil
+}
+
+func (k *kvLimiter) Set(key string, tokens uint64, interval time.Duration) error {
+	k.mtx.Lock()
+	defer k.mtx.Unlock()
+
+	cur, err := k.getState(key)
+	if err != nil {
+		return err
+	}
+	_, err = k.setState(key, state{Tokens: tokens, Remaining: tokens, Interval: interval, LastTake: time.Time{}}, cur.Ver)
+	return err
+}
+
+func (k *kvLimiter) Burst(key string, tokens uint64, interval, validity time.Duration) error {
+	k.mtx.Lock()
+	defer k.mtx.Unlock()
+
+	s, err := k.getState(key)
+	if err != nil {
+		return err
+	}
+	s.Burst = burst{
+		Tokens:   tokens,
+		Interval: interval,
+		ValidTo:  k.clock.Now().Add(validity),
+	}
+	_, err = k.setState(key, s, s.Ver)
+	return err
+}

--- a/storage/limiter_test.go
+++ b/storage/limiter_test.go
@@ -19,13 +19,13 @@ import (
 
 func TestKvLimiter_Basic(t *testing.T) {
 	mc := clock.NewMock()
-	l := &kvLimiter{rs: newRaftStore(t), clock: mc}
+	l := &KVLimiter{rs: newRaftStore(t), clock: mc}
 	tok, rem, err := l.Get("foo")
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), tok)
 	require.Equal(t, uint64(0), rem)
 
-	err = l.Set("foo", 10, time.Second)
+	err = l.Reset("foo", 10, time.Second)
 	require.NoError(t, err)
 
 	tok, rem, err = l.Get("foo")
@@ -47,13 +47,13 @@ func TestKvLimiter_Basic(t *testing.T) {
 
 func TestKvLimiter_Burst(t *testing.T) {
 	mc := clock.NewMock()
-	l := &kvLimiter{rs: newRaftStore(t), clock: mc}
+	l := &KVLimiter{rs: newRaftStore(t), clock: mc}
 	tok, rem, err := l.Get("foo")
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), tok)
 	require.Equal(t, uint64(0), rem)
 
-	err = l.Set("foo", 1, time.Second)
+	err = l.Reset("foo", 1, time.Second)
 	require.NoError(t, err)
 
 	tok, rem, err = l.Get("foo")
@@ -86,13 +86,13 @@ func TestKvLimiter_Burst(t *testing.T) {
 }
 
 func TestKvLimiter_WaitFor(t *testing.T) {
-	l := &kvLimiter{rs: newRaftStore(t), clock: clock.New()}
+	l := &KVLimiter{rs: newRaftStore(t), clock: clock.New()}
 	tok, rem, err := l.Get("foo")
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), tok)
 	require.Equal(t, uint64(0), rem)
 
-	err = l.Set("foo", 1, time.Second)
+	err = l.Reset("foo", 1, time.Second)
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
 	defer cancel()
 

--- a/storage/limiter_test.go
+++ b/storage/limiter_test.go
@@ -1,0 +1,157 @@
+// Copyright JAMF Software, LLC
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/jamf/regatta/storage/kv"
+	"github.com/lni/dragonboat/v4"
+	"github.com/lni/dragonboat/v4/config"
+	"github.com/lni/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKvLimiter_Basic(t *testing.T) {
+	mc := clock.NewMock()
+	l := &kvLimiter{rs: newRaftStore(t), clock: mc}
+	tok, rem, err := l.Get("foo")
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), tok)
+	require.Equal(t, uint64(0), rem)
+
+	err = l.Set("foo", 10, time.Second)
+	require.NoError(t, err)
+
+	tok, rem, err = l.Get("foo")
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), tok)
+
+	rem, _, ok, err := l.Take("foo")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(9), rem)
+
+	mc.Add(5 * time.Second)
+
+	rem, _, ok, err = l.Take("foo")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(58), rem)
+}
+
+func TestKvLimiter_Burst(t *testing.T) {
+	mc := clock.NewMock()
+	l := &kvLimiter{rs: newRaftStore(t), clock: mc}
+	tok, rem, err := l.Get("foo")
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), tok)
+	require.Equal(t, uint64(0), rem)
+
+	err = l.Set("foo", 1, time.Second)
+	require.NoError(t, err)
+
+	tok, rem, err = l.Get("foo")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), tok)
+
+	rem, _, ok, err := l.Take("foo")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(0), rem)
+
+	require.NoError(t, l.Burst("foo", 5, time.Second, 30*time.Second))
+
+	mc.Add(5 * time.Second)
+
+	rem, _, ok, err = l.Take("foo")
+	require.NoError(t, err)
+	require.True(t, ok)
+	// (0 + 5 * 5/s) - 1.
+	require.Equal(t, uint64(24), rem)
+
+	// Missed additional burst tick
+	// (24 + 30 * 1/s) - 1
+	mc.Add(30 * time.Second)
+
+	rem, _, ok, err = l.Take("foo")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(53), rem)
+}
+
+func TestKvLimiter_WaitFor(t *testing.T) {
+	l := &kvLimiter{rs: newRaftStore(t), clock: clock.New()}
+	tok, rem, err := l.Get("foo")
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), tok)
+	require.Equal(t, uint64(0), rem)
+
+	err = l.Set("foo", 1, time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, l.WaitFor(ctx, "foo"))
+	require.NoError(t, l.WaitFor(ctx, "foo"))
+	require.NoError(t, l.WaitFor(ctx, "foo"))
+	require.NoError(t, l.WaitFor(ctx, "foo"))
+	require.NoError(t, l.WaitFor(ctx, "foo"))
+	require.ErrorIs(t, l.WaitFor(ctx, "foo"), context.DeadlineExceeded)
+}
+
+func newRaftStore(t *testing.T) *kv.RaftStore {
+	t.Helper()
+	getTestPort := func() int {
+		l, _ := net.Listen("tcp", "127.0.0.1:0")
+		defer l.Close()
+		return l.Addr().(*net.TCPAddr).Port
+	}
+
+	startRaftNode := func() *dragonboat.NodeHost {
+		testNodeAddress := fmt.Sprintf("127.0.0.1:%d", getTestPort())
+		nhc := config.NodeHostConfig{
+			WALDir:         "wal",
+			NodeHostDir:    "dragonboat",
+			RTTMillisecond: 1,
+			RaftAddress:    testNodeAddress,
+		}
+		_ = nhc.Prepare()
+		nhc.Expert.FS = vfs.NewMem()
+		nhc.Expert.Engine.ExecShards = 1
+		nhc.Expert.LogDB.Shards = 1
+		nh, err := dragonboat.NewNodeHost(nhc)
+		if err != nil {
+			panic(err)
+		}
+
+		cc := config.Config{
+			ReplicaID:          1,
+			ShardID:            1,
+			ElectionRTT:        5,
+			HeartbeatRTT:       1,
+			CheckQuorum:        true,
+			SnapshotEntries:    10000,
+			CompactionOverhead: 5000,
+			WaitReady:          true,
+		}
+
+		err = nh.StartConcurrentReplica(map[uint64]string{1: testNodeAddress}, false, kv.NewLFSM(), cc)
+		if err != nil {
+			panic(err)
+		}
+		require.Eventually(t, func() bool {
+			_, _, ok, _ := nh.GetLeaderID(cc.ReplicaID)
+			return ok
+		}, 5*time.Second, 10*time.Millisecond)
+		return nh
+	}
+
+	node := startRaftNode()
+	t.Cleanup(node.Close)
+	return &kv.RaftStore{NodeHost: node, ClusterID: 1}
+}

--- a/storage/table/manager_test.go
+++ b/storage/table/manager_test.go
@@ -10,6 +10,7 @@ import (
 	pvfs "github.com/cockroachdb/pebble/vfs"
 	"github.com/jamf/regatta/replication/snapshot"
 	serrors "github.com/jamf/regatta/storage/errors"
+	"github.com/jamf/regatta/storage/kv"
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/dragonboat/v4/config"
 	"github.com/lni/vfs"
@@ -30,10 +31,9 @@ func TestManager_CreateTable(t *testing.T) {
 	node, m := startRaftNode(t)
 	defer node.Close()
 
-	tm := NewManager(node, m, minimalTestConfig())
-	r.NoError(tm.Start())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm.Start()
 	defer tm.Close()
-	r.NoError(tm.WaitUntilReady())
 
 	t.Log("create table")
 	_, err := tm.CreateTable(testTableName)
@@ -60,11 +60,10 @@ func TestManager_DeleteTable(t *testing.T) {
 	node, m := startRaftNode(t)
 	defer node.Close()
 
-	tm := NewManager(node, m, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
 	tm.cleanupGracePeriod = 0
-	r.NoError(tm.Start())
+	tm.Start()
 	defer tm.Close()
-	r.NoError(tm.WaitUntilReady())
 
 	t.Log("create table")
 	_, err := tm.CreateTable(testTableName)
@@ -122,10 +121,9 @@ func TestManager_LeaseTable(t *testing.T) {
 
 	node, m := startRaftNode(t)
 	defer node.Close()
-	tm := NewManager(node, m, minimalTestConfig())
-	require.NoError(t, tm.Start())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm.Start()
 	defer tm.Close()
-	require.NoError(t, tm.WaitUntilReady())
 	_, err := tm.CreateTable(existingTable)
 	require.NoError(t, err)
 
@@ -171,10 +169,9 @@ func TestManager_ReturnTable(t *testing.T) {
 
 	node, m := startRaftNode(t)
 	defer node.Close()
-	tm := NewManager(node, m, minimalTestConfig())
-	require.NoError(t, tm.Start())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm.Start()
 	defer tm.Close()
-	require.NoError(t, tm.WaitUntilReady())
 	_, err := tm.CreateTable(existingTable)
 	require.NoError(t, err)
 
@@ -220,10 +217,9 @@ func TestManager_GetTable(t *testing.T) {
 
 	node, m := startRaftNode(t)
 	defer node.Close()
-	tm := NewManager(node, m, minimalTestConfig())
-	require.NoError(t, tm.Start())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm.Start()
 	defer tm.Close()
-	require.NoError(t, tm.WaitUntilReady())
 	_, err := tm.CreateTable(existingTable)
 	require.NoError(t, err)
 
@@ -245,10 +241,9 @@ func TestManager_Restore(t *testing.T) {
 	const existingTable = "existingTable"
 	node, m := startRaftNode(t)
 	defer node.Close()
-	tm := NewManager(node, m, minimalTestConfig())
-	require.NoError(t, tm.Start())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm.Start()
 	defer tm.Close()
-	require.NoError(t, tm.WaitUntilReady())
 	_, err := tm.CreateTable(existingTable)
 	require.NoError(t, err)
 
@@ -272,12 +267,11 @@ func TestManager_reconcile(t *testing.T) {
 	defer node.Close()
 
 	const reconcileInterval = 1 * time.Second
-	tm := NewManager(node, m, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
 	tm.reconcileInterval = reconcileInterval
 
-	r.NoError(tm.Start())
+	tm.Start()
 	defer tm.Close()
-	r.NoError(tm.WaitUntilReady())
 	_, err := tm.createTable(testTableName)
 	r.NoError(err)
 	time.Sleep(reconcileInterval * 3)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The PR covers necessary refactoring for plugging in distributed ratelimiter necessary for efficient back-propagation.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Most of the PR is only a refactor that pulled up KV store from deep downs of table Manager on to the storage Engine layer. The PR introduces distributed ratelimiter in `limiter.go` it is not yet used though as the final plumbing will be done in (hopefully) last part 3.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
