### PR TITLE
feat: follower write API part3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,16 @@ all: build
 
 .PHONY: run
 run: build
-	./regatta leader --dev-mode --raft.address=127.0.0.1:5012 --raft.initial-members='1=127.0.0.1:5012' --tables.names=regatta-test --api.address=http://127.0.0.1:8443 --replication.address=https://127.0.0.1:8444 --replication.ca-filename=hack/replication/ca.crt --replication.cert-filename=hack/replication/server.crt --replication.key-filename=hack/replication/server.key
+	./regatta leader --dev-mode --raft.address=127.0.0.1:5012 --raft.initial-members='1=127.0.0.1:5012' \
+ --tables.names=regatta-test --api.address=http://127.0.0.1:8443 --replication.address=https://127.0.0.1:8444 \
+ --replication.ca-filename=hack/replication/ca.crt --replication.cert-filename=hack/replication/server.crt --replication.key-filename=hack/replication/server.key
 
 .PHONY: run-follower
 run-follower: build
-	./regatta follower --dev-mode --raft.address=127.0.0.1:6012 --raft.initial-members='1=127.0.0.1:6012' --memberlist.address=:7433 --api.address=http://127.0.0.1:9443 --maintenance.enabled=false --rest.address=http://127.0.0.1:8080 --replication.leader-address=https://127.0.0.1:8444 --replication.ca-filename=hack/replication/ca.crt --replication.cert-filename=hack/replication/client.crt --replication.key-filename=hack/replication/client.key --raft.node-host-dir=/tmp/regatta-follower/raft --raft.state-machine-dir=/tmp/regatta-follower/state-machine
+	./regatta follower --dev-mode --raft.address=127.0.0.1:6012 --raft.initial-members='1=127.0.0.1:6012' \
+ --memberlist.address=:7433 --api.address=http://127.0.0.1:9443 --maintenance.enabled=false --rest.address=http://127.0.0.1:8080 \
+ --replication.leader-address=https://127.0.0.1:8444 --replication.ca-filename=hack/replication/ca.crt --replication.cert-filename=hack/replication/client.crt --replication.key-filename=hack/replication/client.key \
+ --raft.node-host-dir=/tmp/regatta-follower/raft --raft.state-machine-dir=/tmp/regatta-follower/state-machine
 
 # Run golangci-lint on the code
 .PHONY: check

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func createAPIServer() (*regattaserver.RegattaServer, error) {
-	addr, secure, net := resolveUrl(viper.GetString("api.address"))
+	addr, secure, net := resolveURL(viper.GetString("api.address"))
 	opts := []grpc.ServerOption{
 		grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: 60 * time.Second}),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
@@ -64,7 +64,7 @@ func createAPIServer() (*regattaserver.RegattaServer, error) {
 	return regattaserver.NewServer(addr, net, opts...), nil
 }
 
-func resolveUrl(urlStr string) (addr string, secure bool, network string) {
+func resolveURL(urlStr string) (addr string, secure bool, network string) {
 	u, err := url.Parse(urlStr)
 	if err != nil {
 		log.Panicf("cannot parse address: %v", err)

--- a/cmd/follower.go
+++ b/cmd/follower.go
@@ -172,7 +172,7 @@ func follower(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("cannot create replication conn: %w", err)
 	}
 	{
-		d := replication.NewManager(engine, conn, replication.Config{
+		d := replication.NewManager(engine, nQueue, conn, replication.Config{
 			ReconcileInterval: viper.GetDuration("replication.reconcile-interval"),
 			Workers: replication.WorkerConfig{
 				PollInterval:        viper.GetDuration("replication.poll-interval"),
@@ -218,7 +218,7 @@ func follower(_ *cobra.Command, _ []string) error {
 		}
 
 		// Create REST server
-		addr, _, _ := resolveUrl(viper.GetString("rest.address"))
+		addr, _, _ := resolveURL(viper.GetString("rest.address"))
 		hs := regattaserver.NewRESTServer(addr, viper.GetDuration("rest.read-timeout"))
 		go func() {
 			if err := hs.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
@@ -235,7 +235,7 @@ func follower(_ *cobra.Command, _ []string) error {
 }
 
 func createReplicationConn() (*grpc.ClientConn, error) {
-	addr, secure, net := resolveUrl(viper.GetString("replication.leader-address"))
+	addr, secure, net := resolveURL(viper.GetString("replication.leader-address"))
 	var creds grpc.DialOption
 	if secure {
 		c, err := cert.New(viper.GetString("replication.cert-filename"), viper.GetString("replication.key-filename"))

--- a/cmd/leader.go
+++ b/cmd/leader.go
@@ -239,7 +239,7 @@ func leader(_ *cobra.Command, _ []string) error {
 		}
 
 		// Create REST server
-		addr, _, _ := resolveUrl(viper.GetString("rest.address"))
+		addr, _, _ := resolveURL(viper.GetString("rest.address"))
 		hs := regattaserver.NewRESTServer(addr, viper.GetDuration("rest.read-timeout"))
 		go func() {
 			if err := hs.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
@@ -256,7 +256,7 @@ func leader(_ *cobra.Command, _ []string) error {
 }
 
 func createReplicationServer(log *zap.Logger) (*regattaserver.RegattaServer, error) {
-	addr, secure, net := resolveUrl(viper.GetString("replication.address"))
+	addr, secure, net := resolveURL(viper.GetString("replication.address"))
 	opts := []grpc.ServerOption{
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			grpc_prometheus.StreamServerInterceptor,

--- a/replication/replication.go
+++ b/replication/replication.go
@@ -35,7 +35,7 @@ type Config struct {
 }
 
 // NewManager constructs a new replication Manager out of tables.Manager, dragonboat.NodeHost and replication API grpc.ClientConn.
-func NewManager(e *storage.Engine, conn *grpc.ClientConn, cfg Config) *Manager {
+func NewManager(e *storage.Engine, queue *storage.IndexNotificationQueue, conn *grpc.ClientConn, cfg Config) *Manager {
 	replicationLog := zap.S().Named("replication")
 
 	replicationIndexGauge := prometheus.NewGaugeVec(
@@ -56,6 +56,7 @@ func NewManager(e *storage.Engine, conn *grpc.ClientConn, cfg Config) *Manager {
 		engine:            e,
 		metadataClient:    regattapb.NewMetadataClient(conn),
 		factory: &workerFactory{
+			queue:             queue,
 			reconcileInterval: cfg.ReconcileInterval,
 			pollInterval:      cfg.Workers.PollInterval,
 			leaseInterval:     cfg.Workers.LeaseInterval,

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -93,7 +93,7 @@ func TestManager_reconcile(t *testing.T) {
 		regattapb.RegisterLogServer(server, s)
 	})
 
-	m := NewManager(followerEngine, storage.NewNotificationQueue(), conn, Config{
+	m := NewManager(followerEngine, nil, conn, Config{
 		ReconcileInterval: 250 * time.Millisecond,
 		Workers: WorkerConfig{
 			PollInterval:        10 * time.Millisecond,
@@ -125,7 +125,7 @@ func TestManager_reconcileTables(t *testing.T) {
 	conn, err := grpc.Dial(srv.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	r.NoError(err)
 
-	m := NewManager(followerEngine, storage.NewNotificationQueue(), conn, Config{})
+	m := NewManager(followerEngine, nil, conn, Config{})
 
 	t.Log("create table")
 	_, err = leaderEngine.CreateTable("test")
@@ -178,7 +178,7 @@ func TestManager_recover(t *testing.T) {
 		regattapb.RegisterSnapshotServer(server, s)
 	})
 
-	m := NewManager(followerEngine, storage.NewNotificationQueue(), conn, Config{
+	m := NewManager(followerEngine, nil, conn, Config{
 		ReconcileInterval: 250 * time.Millisecond,
 		Workers: WorkerConfig{
 			PollInterval:        10 * time.Millisecond,

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -93,7 +93,7 @@ func TestManager_reconcile(t *testing.T) {
 		regattapb.RegisterLogServer(server, s)
 	})
 
-	m := NewManager(followerEngine, conn, Config{
+	m := NewManager(followerEngine, storage.NewNotificationQueue(), conn, Config{
 		ReconcileInterval: 250 * time.Millisecond,
 		Workers: WorkerConfig{
 			PollInterval:        10 * time.Millisecond,
@@ -125,7 +125,7 @@ func TestManager_reconcileTables(t *testing.T) {
 	conn, err := grpc.Dial(srv.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	r.NoError(err)
 
-	m := NewManager(followerEngine, conn, Config{})
+	m := NewManager(followerEngine, storage.NewNotificationQueue(), conn, Config{})
 
 	t.Log("create table")
 	_, err = leaderEngine.CreateTable("test")
@@ -153,7 +153,7 @@ func TestManager_reconcileTables(t *testing.T) {
 	r.Len(tabs, 2)
 }
 
-func TestWorker_recover(t *testing.T) {
+func TestManager_recover(t *testing.T) {
 	r := require.New(t)
 	t.Log("start follower Raft")
 	_, followerEngine := prepareLeaderAndFollowerEngine(t)
@@ -178,7 +178,7 @@ func TestWorker_recover(t *testing.T) {
 		regattapb.RegisterSnapshotServer(server, s)
 	})
 
-	m := NewManager(followerEngine, conn, Config{
+	m := NewManager(followerEngine, storage.NewNotificationQueue(), conn, Config{
 		ReconcileInterval: 250 * time.Millisecond,
 		Workers: WorkerConfig{
 			PollInterval:        10 * time.Millisecond,

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -708,7 +708,7 @@ func TestEngine_MemberList(t *testing.T) {
 			prepare: func(t *testing.T, e *Engine) {},
 			wantErr: require.NoError,
 			assert: func(t *testing.T, resp *regattapb.MemberListResponse) {
-				require.Equal(t, 1, len(resp.Members))
+				require.Len(t, resp.Members, 1)
 			},
 		},
 	}

--- a/storage/limiter.go
+++ b/storage/limiter.go
@@ -121,7 +121,7 @@ func (k *KVLimiter) Take(key string) (remaining uint64, reset time.Time, ok bool
 	}
 
 	if s.Remaining > 0 {
-		s.Remaining -= 1
+		s.Remaining--
 		s.LastTake = now
 		news, err := k.setState(key, s, s.Ver)
 		if err != nil {

--- a/storage/limiter_test.go
+++ b/storage/limiter_test.go
@@ -31,6 +31,7 @@ func TestKvLimiter_Basic(t *testing.T) {
 	tok, rem, err = l.Get("foo")
 	require.NoError(t, err)
 	require.Equal(t, uint64(10), tok)
+	require.Equal(t, uint64(10), rem)
 
 	rem, _, ok, err := l.Take("foo")
 	require.NoError(t, err)
@@ -59,6 +60,7 @@ func TestKvLimiter_Burst(t *testing.T) {
 	tok, rem, err = l.Get("foo")
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), tok)
+	require.Equal(t, uint64(1), rem)
 
 	rem, _, ok, err := l.Take("foo")
 	require.NoError(t, err)

--- a/storage/limiter_test.go
+++ b/storage/limiter_test.go
@@ -92,7 +92,7 @@ func TestKvLimiter_WaitFor(t *testing.T) {
 	require.Equal(t, uint64(0), tok)
 	require.Equal(t, uint64(0), rem)
 
-	err = l.Reset("foo", 1, time.Second)
+	require.NoError(t, l.Reset("foo", 1, time.Second))
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
 	defer cancel()
 

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -40,7 +40,7 @@ func NewNotificationQueue() *IndexNotificationQueue {
 		add:    make(chan *item),
 		notif:  make(chan notification),
 		closed: make(chan struct{}),
-		items: util.NewSyncMap(func(k string) *heap.Heap[*item] {
+		items: util.NewSyncMap(func(_ string) *heap.Heap[*item] {
 			return heap.New((*item).less)
 		}),
 	}
@@ -94,6 +94,11 @@ func (q *IndexNotificationQueue) Run() {
 			}
 		}
 	}
+}
+
+func (q *IndexNotificationQueue) Len(table string) int {
+	h, _ := q.items.Load(table)
+	return h.Len()
 }
 
 func (q *IndexNotificationQueue) Notify(table string, revision uint64) {

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -27,8 +27,7 @@ func TestNotificationQueue(t *testing.T) {
 	q.Notify("foo", 20)
 	chanelClosed(t, w)
 
-	h, _ := q.items.Load("foo")
-	require.Zero(t, h.Len())
+	require.Zero(t, q.Len("foo"))
 }
 
 func TestNotificationQueueTimeout(t *testing.T) {
@@ -46,7 +45,7 @@ func TestNotificationQueueTimeout(t *testing.T) {
 	require.Eventually(t, func() bool {
 		select {
 		case err := <-w:
-			return assert.Error(t, err, context.Canceled)
+			return assert.ErrorIs(t, err, context.Canceled)
 		default:
 			return false
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The last part of initial implementation of Follower write API. This PR connects few bits together and focuses mostly on dynamic rate of polls from Replication API depending on the queue of unprocessed (not backfilled) writes.

## Related Issue
Improves: #113

## Motivation and Context

This change will speed up regular poll times by issuing bursts to replication scheduler to help reducing latency of writes.
For now the Bursts are static but could be improved to involve calculation from e.g. Lag or/and length of backfill queue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
