### PR TITLE
feat: API server limits implementation

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -37,6 +37,9 @@ func init() {
 	apiFlagSet.Bool("api.client-cert-auth", false, "API server client certificate auth enabled. If set to true the api.ca-filename should be provided as well.")
 	apiFlagSet.String("api.allowed-cn", "", "AllowedCN is a CN which must be provided by a client.")
 	apiFlagSet.String("api.allowed-hostname", "", "AllowedHostname is an IP address or hostname that must match the TLS certificate provided by a client.")
+	apiFlagSet.Uint32("api.max-concurrent-connections", 0, "Maximum number of allowed concurrent client connections. Default of 0 means no limit.")
+	apiFlagSet.Uint32("api.max-concurrent-streams", 0, "Maximum number of concurrent streams open. Default of 0 means no limit.")
+	apiFlagSet.Int("api.stream-workers", 0, "Number of workers to use to process incoming streams. These workers are pre-started and should reduce an overhead of stack allocation as well as prevent potential overload of a storage layer. Default of 0 means number of CPUs + 1, any negative number will result in unlimited workers.")
 
 	// REST API flags
 	restFlagSet.String("rest.address", "http://127.0.0.1:8079", "REST API server address.")

--- a/cmd/follower.go
+++ b/cmd/follower.go
@@ -212,7 +212,7 @@ func follower(_ *cobra.Command, _ []string) error {
 
 			// Start server
 			go func() {
-				if err := regatta.ListenAndServe(); err != nil {
+				if err := regatta.Serve(); err != nil {
 					log.Errorf("grpc listenAndServe failed: %v", err)
 				}
 			}()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,12 @@ nav_order: 999
 ---
 
 # Changelog
-## v0.5.0 (unreleased)
+## v0.5.1 (unreleased)
+
+### Bugfixes
+* Fix storage compaction metrics.
+
+## v0.5.0
 
 ### Highlights
 #### Follower to leader replication

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ nav_order: 999
 # Changelog
 ## v0.5.1 (unreleased)
 
+### Improvements
+* API server will now by default use fixed number of pre-created worker go routines for stream handling. The behaviour could be overridden by setting `api.stream-workers` config value.
+
+### Security
+* API server max number of concurrent connections can be set by `api.max-concurrent-connections` config value.
+* API server max number of concurrent streams can be set by `api.max-concurrent-streams` config value.
+
 ### Bugfixes
 * Fix storage compaction metrics.
 

--- a/docs/operations_guide/cli/regatta_follower.md
+++ b/docs/operations_guide/cli/regatta_follower.md
@@ -23,6 +23,9 @@ regatta follower [flags]
       --api.cert-filename string                              Path to the API server certificate.
       --api.client-cert-auth                                  API server client certificate auth enabled. If set to true the api.ca-filename should be provided as well.
       --api.key-filename string                               Path to the API server private key file.
+      --api.max-concurrent-connections uint32                 Maximum number of allowed concurrent client connections. Default of 0 means no limit.
+      --api.max-concurrent-streams uint32                     Maximum number of concurrent streams open. Default of 0 means no limit.
+      --api.stream-workers int                                Number of workers to use to process incoming streams. These workers are pre-started and should reduce an overhead of stack allocation as well as prevent potential overload of a storage layer. Default of 0 means number of CPUs + 1, any negative number will result in unlimited workers.
       --dev-mode                                              Development mode enabled (verbose logging, human-friendly log format).
   -h, --help                                                  help for follower
       --log-level string                                      Log level: DEBUG/INFO/WARN/ERROR. (default "INFO")

--- a/docs/operations_guide/cli/regatta_leader.md
+++ b/docs/operations_guide/cli/regatta_leader.md
@@ -23,6 +23,9 @@ regatta leader [flags]
       --api.cert-filename string                               Path to the API server certificate.
       --api.client-cert-auth                                   API server client certificate auth enabled. If set to true the api.ca-filename should be provided as well.
       --api.key-filename string                                Path to the API server private key file.
+      --api.max-concurrent-connections uint32                  Maximum number of allowed concurrent client connections. Default of 0 means no limit.
+      --api.max-concurrent-streams uint32                      Maximum number of concurrent streams open. Default of 0 means no limit.
+      --api.stream-workers int                                 Number of workers to use to process incoming streams. These workers are pre-started and should reduce an overhead of stack allocation as well as prevent potential overload of a storage layer. Default of 0 means number of CPUs + 1, any negative number will result in unlimited workers.
       --dev-mode                                               Development mode enabled (verbose logging, human-friendly log format).
   -h, --help                                                   help for leader
       --log-level string                                       Log level: DEBUG/INFO/WARN/ERROR. (default "INFO")

--- a/replication/worker_test.go
+++ b/replication/worker_test.go
@@ -72,7 +72,7 @@ func TestWorker_do(t *testing.T) {
 	r.NoError(fillData(keyCount, at))
 
 	t.Log("create worker")
-	conn, err := grpc.NewClient(srv.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(srv.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	r.NoError(err)
 	logger, obs := observer.New(zap.DebugLevel)
 	queue := storage.NewNotificationQueue()
@@ -221,7 +221,7 @@ func TestWorker_recover(t *testing.T) {
 	r.NoError(err)
 
 	t.Log("create worker")
-	conn, err := grpc.NewClient(srv.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(srv.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	r.NoError(err)
 	w := &worker{table: "test", workerFactory: &workerFactory{snapshotTimeout: time.Minute, engine: followerEngine, queue: storage.NewNotificationQueue(), snapshotClient: regattapb.NewSnapshotClient(conn)}, log: zaptest.NewLogger(t).Sugar()}
 

--- a/storage/table/fsm/metrics.go
+++ b/storage/table/fsm/metrics.go
@@ -38,7 +38,7 @@ type metrics struct {
 	readAmplification       prometheus.Gauge
 	totalWriteAmplification prometheus.Gauge
 	totalBytesIn            prometheus.Gauge
-	compactCount            *prometheus.SummaryVec
+	compactCount            *prometheus.GaugeVec
 	compactDebt             prometheus.Gauge
 	applied                 atomic.Uint64
 	collected               *pebble.Metrics
@@ -156,8 +156,8 @@ func newMetrics(tableName string, clusterID uint64) *metrics {
 				},
 			},
 		),
-		compactCount: prometheus.NewSummaryVec(
-			prometheus.SummaryOpts{
+		compactCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
 				Name: compactionMetricName,
 				Help: "Regatta table storage compaction count by kind",
 				ConstLabels: map[string]string{
@@ -214,13 +214,13 @@ func (p *metrics) Collect(ch chan<- prometheus.Metric) {
 	p.totalBytesIn.Collect(ch)
 
 	compact := p.collected.Compact
-	p.compactCount.With(prometheus.Labels{"kind": "total"}).Observe(float64(compact.Count))
-	p.compactCount.With(prometheus.Labels{"kind": "default"}).Observe(float64(compact.DefaultCount))
-	p.compactCount.With(prometheus.Labels{"kind": "delete"}).Observe(float64(compact.DeleteOnlyCount))
-	p.compactCount.With(prometheus.Labels{"kind": "elision"}).Observe(float64(compact.ElisionOnlyCount))
-	p.compactCount.With(prometheus.Labels{"kind": "move"}).Observe(float64(compact.MoveCount))
-	p.compactCount.With(prometheus.Labels{"kind": "read"}).Observe(float64(compact.ReadCount))
-	p.compactCount.With(prometheus.Labels{"kind": "multilevel"}).Observe(float64(compact.MultiLevelCount))
+	p.compactCount.With(prometheus.Labels{"kind": "total"}).Set(float64(compact.Count))
+	p.compactCount.With(prometheus.Labels{"kind": "default"}).Set(float64(compact.DefaultCount))
+	p.compactCount.With(prometheus.Labels{"kind": "delete"}).Set(float64(compact.DeleteOnlyCount))
+	p.compactCount.With(prometheus.Labels{"kind": "elision"}).Set(float64(compact.ElisionOnlyCount))
+	p.compactCount.With(prometheus.Labels{"kind": "move"}).Set(float64(compact.MoveCount))
+	p.compactCount.With(prometheus.Labels{"kind": "read"}).Set(float64(compact.ReadCount))
+	p.compactCount.With(prometheus.Labels{"kind": "multilevel"}).Set(float64(compact.MultiLevelCount))
 	p.compactCount.Collect(ch)
 
 	p.compactDebt.Set(float64(compact.EstimatedDebt))

--- a/storage/table/fsm/testdata/metrics
+++ b/storage/table/fsm/testdata/metrics
@@ -18,21 +18,14 @@ regatta_table_storage_cache_misses{shard_id="1",table="test",type="table"} 0
 regatta_table_storage_cache_size_bytes{shard_id="1",table="test",type="block"} 0
 regatta_table_storage_cache_size_bytes{shard_id="1",table="test",type="table"} 0
 # HELP regatta_table_storage_compaction Regatta table storage compaction count by kind
-# TYPE regatta_table_storage_compaction summary
-regatta_table_storage_compaction_sum{kind="default",shard_id="1",table="test"} 0
-regatta_table_storage_compaction_count{kind="default",shard_id="1",table="test"} 2
-regatta_table_storage_compaction_sum{kind="delete",shard_id="1",table="test"} 0
-regatta_table_storage_compaction_count{kind="delete",shard_id="1",table="test"} 2
-regatta_table_storage_compaction_sum{kind="elision",shard_id="1",table="test"} 0
-regatta_table_storage_compaction_count{kind="elision",shard_id="1",table="test"} 2
-regatta_table_storage_compaction_sum{kind="move",shard_id="1",table="test"} 0
-regatta_table_storage_compaction_count{kind="move",shard_id="1",table="test"} 2
-regatta_table_storage_compaction_sum{kind="multilevel",shard_id="1",table="test"} 0
-regatta_table_storage_compaction_count{kind="multilevel",shard_id="1",table="test"} 2
-regatta_table_storage_compaction_sum{kind="read",shard_id="1",table="test"} 0
-regatta_table_storage_compaction_count{kind="read",shard_id="1",table="test"} 2
-regatta_table_storage_compaction_sum{kind="total",shard_id="1",table="test"} 0
-regatta_table_storage_compaction_count{kind="total",shard_id="1",table="test"} 2
+# TYPE regatta_table_storage_compaction gauge
+regatta_table_storage_compaction{kind="default",shard_id="1",table="test"} 0
+regatta_table_storage_compaction{kind="delete",shard_id="1",table="test"} 0
+regatta_table_storage_compaction{kind="elision",shard_id="1",table="test"} 0
+regatta_table_storage_compaction{kind="move",shard_id="1",table="test"} 0
+regatta_table_storage_compaction{kind="multilevel",shard_id="1",table="test"} 0
+regatta_table_storage_compaction{kind="read",shard_id="1",table="test"} 0
+regatta_table_storage_compaction{kind="total",shard_id="1",table="test"} 0
 # HELP regatta_table_storage_compaction_debt_bytes Regatta table storage compaction debt in bytes
 # TYPE regatta_table_storage_compaction_debt_bytes gauge
 regatta_table_storage_compaction_debt_bytes{shard_id="1",table="test"} 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The multiple options provided to a server operator to limit or throttle the usage.
* By limiting a number of connections.
* By limiting max number of concurrent streams.
* By limiting the number of goroutines potentially spawned for handling streams.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
