### PR TITLE
feat: pull iterator with coroutine

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ nav_order: 999
 
 ### Improvements
 * API server will now by default use fixed number of pre-created worker go routines for stream handling. The behaviour could be overridden by setting `api.stream-workers` config value.
+* regatta.v1.KV/IterateRange now uses coroutine instead of full goroutine.
 
 ### Security
 * API server max number of concurrent connections can be set by `api.max-concurrent-connections` config value.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improvement to pull iterator switch. Mostly copied from stdlib impl.

## Motivation and Context

Starting additional goroutines to handle IterateRange calls is rather wasteful and could be solved by coro.

## How Has This Been Tested?

UTs
